### PR TITLE
Phase 2: axum HTTP API + 20 unit tests

### DIFF
--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -62,18 +62,164 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "auto-future"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1e7e457ea78e524f48639f551fd79703ac3f2237f5ecccdf4708f8a75ad373"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-test"
+version = "16.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e3a443d2608936a02a222da7b746eb412fede7225b3030b64fe9be99eab8dc"
+dependencies = [
+ "anyhow",
+ "assert-json-diff",
+ "auto-future",
+ "axum",
+ "bytes",
+ "bytesize",
+ "cookie",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "mime",
+ "pretty_assertions",
+ "reserve-port",
+ "rust-multipart-rfc7578_2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "tokio",
+ "tower",
+ "url",
+]
+
+[[package]]
 name = "bambu-bridge"
 version = "0.1.0"
 dependencies = [
+ "axum",
+ "axum-test",
  "cc",
  "clap",
  "libc",
  "serde",
  "serde_json",
+ "tokio",
  "toml",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bytesize"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
 
 [[package]]
 name = "cc"
@@ -138,16 +284,129 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "hashbrown"
@@ -160,6 +419,206 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http 1.4.0",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -196,6 +655,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,10 +685,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -224,6 +731,12 @@ checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "once_cell"
@@ -238,10 +751,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -262,6 +838,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +892,49 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reserve-port"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94070964579245eb2f76e62a7668fe87bd9969ed6c41256f3bf614e3323dd3cc"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rust-multipart-rfc7578_2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b748410c0afdef2ebbe3685a6a862e2ee937127cdaae623336a459451c8d57"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "mime",
+ "mime_guess",
+ "rand",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -322,11 +980,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -346,10 +1027,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -369,12 +1082,138 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tokio"
+version = "1.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -419,11 +1258,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http 1.4.0",
+ "http-body",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -480,10 +1364,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -496,6 +1410,27 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "windows-link"
@@ -519,6 +1454,115 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -6,13 +6,19 @@ description = "Rust bridge daemon for Bambu Lab printers via libbambu_networking
 license = "MIT"
 
 [dependencies]
+axum = "0.7"
 clap = { version = "4", features = ["derive", "env"] }
+libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1", features = ["full"] }
 toml = "0.8"
+tower-http = { version = "0.6", features = ["cors", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-libc = "0.2"
 
 [build-dependencies]
 cc = "1"
+
+[dev-dependencies]
+axum-test = "16"

--- a/bridge/src/agent.rs
+++ b/bridge/src/agent.rs
@@ -13,6 +13,7 @@ use crate::callbacks::{self, CallbackState};
 use crate::ffi;
 
 /// Credentials loaded from `credentials.toml` or a token JSON file.
+#[derive(Debug)]
 pub struct Credentials {
     pub token: String,
     pub refresh_token: String,
@@ -387,12 +388,127 @@ impl BambuAgent {
         self.agent
     }
 
+    /// Create a null agent for testing (no FFI calls allowed).
+    /// # Safety
+    /// Only for tests — calling any FFI method on this agent will crash.
+    #[cfg(test)]
+    pub unsafe fn test_null() -> Self {
+        Self {
+            agent: std::ptr::null_mut(),
+            state: Box::new(CallbackState::new()),
+        }
+    }
+
     /// Poll an atomic bool flag until it becomes true or timeout elapses.
     fn poll_flag(&self, flag: &std::sync::atomic::AtomicBool, timeout: Duration) {
         let start = std::time::Instant::now();
         while start.elapsed() < timeout && !flag.load(Ordering::SeqCst) {
             std::thread::sleep(Duration::from_millis(50));
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn credentials_from_token_json_valid() {
+        let json = r#"{"token":"abc123","refreshToken":"ref456","uid":"42","name":"Test","email":"t@t.com"}"#;
+        let c = Credentials::from_token_json(json).unwrap();
+        assert_eq!(c.token, "abc123");
+        assert_eq!(c.refresh_token, "ref456");
+        assert_eq!(c.uid, "42");
+        assert_eq!(c.name, "Test");
+        assert_eq!(c.email, "t@t.com");
+    }
+
+    #[test]
+    fn credentials_from_token_json_missing_token() {
+        let json = r#"{"uid":"42"}"#;
+        let err = Credentials::from_token_json(json).unwrap_err();
+        assert!(err.contains("token"), "expected token error, got: {err}");
+    }
+
+    #[test]
+    fn credentials_from_token_json_invalid() {
+        let err = Credentials::from_token_json("not json").unwrap_err();
+        assert!(err.contains("invalid JSON"));
+    }
+
+    #[test]
+    fn credentials_from_toml_valid() {
+        let dir = std::env::temp_dir().join("bambu_test_creds");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("credentials.toml");
+        std::fs::write(
+            &path,
+            r#"
+[cloud]
+token = "tok123"
+refresh_token = "ref789"
+uid = "99"
+email = "user@example.com"
+"#,
+        )
+        .unwrap();
+
+        let c = Credentials::from_toml(&path).unwrap();
+        assert_eq!(c.token, "tok123");
+        assert_eq!(c.refresh_token, "ref789");
+        assert_eq!(c.uid, "99");
+        assert_eq!(c.email, "user@example.com");
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn credentials_from_toml_no_cloud_section() {
+        let dir = std::env::temp_dir().join("bambu_test_creds2");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("bad.toml");
+        std::fs::write(&path, "[other]\nfoo = \"bar\"\n").unwrap();
+
+        let err = Credentials::from_toml(&path).unwrap_err();
+        assert!(err.contains("cloud"), "expected cloud error, got: {err}");
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn credentials_to_user_json_structure() {
+        let c = Credentials {
+            token: "t".into(),
+            refresh_token: "r".into(),
+            uid: "u".into(),
+            name: "n".into(),
+            email: "e".into(),
+        };
+        let json = c.to_user_json();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["data"]["token"], "t");
+        assert_eq!(v["data"]["refresh_token"], "r");
+        assert_eq!(v["data"]["user"]["uid"], "u");
+        assert_eq!(v["data"]["user"]["name"], "n");
+        assert_eq!(v["data"]["user"]["account"], "e");
+    }
+
+    #[test]
+    fn credentials_to_user_json_empty_refresh_falls_back_to_token() {
+        let c = Credentials {
+            token: "mytoken".into(),
+            refresh_token: "".into(),
+            uid: "".into(),
+            name: "".into(),
+            email: "".into(),
+        };
+        let json = c.to_user_json();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["data"]["refresh_token"], "mytoken");
     }
 }
 

--- a/bridge/src/callbacks.rs
+++ b/bridge/src/callbacks.rs
@@ -102,3 +102,105 @@ pub extern "C" fn on_subscribe_failure(topic: *const c_char, _ctx: *mut c_void) 
     let t = unsafe { cstr_to_str(topic) };
     tracing::warn!(topic = t, "subscribe_failure callback");
 }
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn callback_state_new_defaults() {
+        let s = CallbackState::new();
+        assert!(!s.server_connected.load(Ordering::SeqCst));
+        assert!(!s.user_logged_in.load(Ordering::SeqCst));
+        assert!(!s.printer_subscribed.load(Ordering::SeqCst));
+        assert!(s.drain_messages().is_empty());
+    }
+
+    #[test]
+    fn drain_messages_empties_buffer() {
+        let s = CallbackState::new();
+        {
+            let mut msgs = s.messages.lock().unwrap();
+            msgs.push(MqttMessage {
+                dev_id: "dev1".into(),
+                payload: "hello".into(),
+            });
+            msgs.push(MqttMessage {
+                dev_id: "dev2".into(),
+                payload: "world".into(),
+            });
+        }
+        let drained = s.drain_messages();
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].dev_id, "dev1");
+        assert_eq!(drained[1].payload, "world");
+
+        // Buffer should be empty now
+        assert!(s.drain_messages().is_empty());
+    }
+
+    #[test]
+    fn on_server_connected_sets_flag() {
+        let s = Box::new(CallbackState::new());
+        let ctx = &*s as *const CallbackState as *mut c_void;
+        on_server_connected(0, 0, ctx);
+        assert!(s.server_connected.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn on_server_connected_nonzero_rc_does_not_set() {
+        let s = Box::new(CallbackState::new());
+        let ctx = &*s as *const CallbackState as *mut c_void;
+        on_server_connected(1, 0, ctx);
+        assert!(!s.server_connected.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn on_message_stores_payload() {
+        let s = Box::new(CallbackState::new());
+        let ctx = &*s as *const CallbackState as *mut c_void;
+        let dev = CString::new("DEVICE1").unwrap();
+        let msg = CString::new(r#"{"gcode_state":"RUNNING"}"#).unwrap();
+        on_message(dev.as_ptr(), msg.as_ptr(), ctx);
+
+        let msgs = s.drain_messages();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].dev_id, "DEVICE1");
+        assert!(msgs[0].payload.contains("gcode_state"));
+    }
+
+    #[test]
+    fn on_message_ignores_empty() {
+        let s = Box::new(CallbackState::new());
+        let ctx = &*s as *const CallbackState as *mut c_void;
+        let dev = CString::new("DEV").unwrap();
+        let empty = CString::new("").unwrap();
+        let braces = CString::new("{}").unwrap();
+        on_message(dev.as_ptr(), empty.as_ptr(), ctx);
+        on_message(dev.as_ptr(), braces.as_ptr(), ctx);
+
+        assert!(s.drain_messages().is_empty());
+    }
+
+    #[test]
+    fn on_user_login_sets_flag() {
+        let s = Box::new(CallbackState::new());
+        let ctx = &*s as *const CallbackState as *mut c_void;
+        on_user_login(0, 1, ctx);
+        assert!(s.user_logged_in.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn on_printer_connected_sets_flag() {
+        let s = Box::new(CallbackState::new());
+        let ctx = &*s as *const CallbackState as *mut c_void;
+        let topic = CString::new("01P00A451601106").unwrap();
+        on_printer_connected(topic.as_ptr(), ctx);
+        assert!(s.printer_subscribed.load(Ordering::SeqCst));
+    }
+}

--- a/bridge/src/main.rs
+++ b/bridge/src/main.rs
@@ -1,13 +1,15 @@
 //! bambu-bridge — Rust CLI for Bambu Lab printer status and monitoring.
 //!
-//! Phase 1: `status` and `watch` subcommands, replacing the C++ bridge
-//! for read-only operations.
+//! Phase 1: `status` and `watch` subcommands (one-shot / stdin-driven)
+//! Phase 2: `daemon` subcommand — axum HTTP API on localhost
 
 mod agent;
 mod callbacks;
 mod ffi;
+mod server;
 
 use std::io::{self, BufRead, Write};
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::process;
 use std::time::Duration;
@@ -15,30 +17,6 @@ use std::time::Duration;
 use clap::{Parser, Subcommand};
 
 use agent::{BambuAgent, Credentials};
-
-/// Saved original stdout fd, used to restore after suppressing library noise.
-static mut SAVED_STDOUT: i32 = -1;
-
-/// Suppress stdout to hide library noise (e.g. "use_count = 4").
-/// Logs (tracing) go to stderr and are unaffected.
-fn suppress_stdout() {
-    unsafe {
-        SAVED_STDOUT = libc::dup(1);
-        let devnull = libc::open(b"/dev/null\0".as_ptr() as *const _, libc::O_WRONLY);
-        if devnull >= 0 {
-            libc::dup2(devnull, 1);
-            libc::close(devnull);
-        }
-    }
-}
-
-/// Fast exit that skips atexit handlers, avoiding .so MQTT thread cleanup hangs.
-fn fast_exit(code: i32) -> ! {
-    use std::io::Write;
-    let _ = io::stdout().flush();
-    let _ = io::stderr().flush();
-    unsafe { libc::_exit(code) }
-}
 
 #[derive(Parser)]
 #[command(name = "bambu-bridge", about = "Bambu Lab printer bridge")]
@@ -75,10 +53,53 @@ enum Command {
         /// Path to token JSON file or credentials TOML
         credentials: PathBuf,
     },
+    /// Start HTTP API daemon on localhost
+    Daemon {
+        /// Path to token JSON file or credentials TOML
+        credentials: PathBuf,
+        /// Port to listen on
+        #[arg(short, long, default_value = "8765")]
+        port: u16,
+        /// Bind address
+        #[arg(long, default_value = "127.0.0.1")]
+        bind: String,
+    },
+}
+
+/// Saved original stdout fd, used to restore after suppressing library noise.
+static mut SAVED_STDOUT: i32 = -1;
+
+/// Suppress stdout to hide library noise (e.g. "use_count = 4").
+/// Logs (tracing) go to stderr and are unaffected.
+fn suppress_stdout() {
+    unsafe {
+        SAVED_STDOUT = libc::dup(1);
+        let devnull = libc::open(b"/dev/null\0".as_ptr() as *const _, libc::O_WRONLY);
+        if devnull >= 0 {
+            libc::dup2(devnull, 1);
+            libc::close(devnull);
+        }
+    }
+}
+
+/// Restore stdout after suppression.
+fn restore_stdout() {
+    unsafe {
+        if SAVED_STDOUT >= 0 {
+            libc::dup2(SAVED_STDOUT, 1);
+        }
+    }
+}
+
+/// Fast exit that skips atexit handlers, avoiding .so MQTT thread cleanup hangs.
+fn fast_exit(code: i32) -> ! {
+    use std::io::Write;
+    let _ = io::stdout().flush();
+    let _ = io::stderr().flush();
+    unsafe { libc::_exit(code) }
 }
 
 fn load_credentials(path: &PathBuf) -> Credentials {
-    // Try TOML first (has [cloud] section), fall back to raw JSON
     if let Some(ext) = path.extension() {
         if ext == "toml" {
             match Credentials::from_toml(path) {
@@ -133,9 +154,7 @@ fn cmd_status(agent: &BambuAgent, device_id: &str) {
     }
 
     let messages = agent.drain_messages();
-
-    // Restore stdout (was suppressed to hide library noise like "use_count = 4")
-    unsafe { libc::dup2(SAVED_STDOUT, 1) };
+    restore_stdout();
 
     match best_message(&messages) {
         Some(msg) => {
@@ -152,7 +171,6 @@ fn cmd_watch(agent: &BambuAgent, device_id: &str) {
     let dev_c = std::ffi::CString::new(device_id).unwrap();
     let module = std::ffi::CString::new("device").unwrap();
 
-    // Subscribe once
     unsafe {
         ffi::bambu_shim_set_user_selected_machine(agent.agent_ptr(), dev_c.as_ptr());
     }
@@ -164,7 +182,6 @@ fn cmd_watch(agent: &BambuAgent, device_id: &str) {
         ffi::bambu_shim_start_subscribe(agent.agent_ptr(), module.as_ptr());
     }
 
-    // Wait for subscription
     let start = std::time::Instant::now();
     while start.elapsed() < Duration::from_secs(3)
         && !agent
@@ -175,12 +192,10 @@ fn cmd_watch(agent: &BambuAgent, device_id: &str) {
         std::thread::sleep(Duration::from_millis(100));
     }
 
-    // Restore stdout and signal readiness
-    unsafe { libc::dup2(SAVED_STDOUT, 1) };
+    restore_stdout();
     println!("{{\"ready\":true}}");
     io::stdout().flush().unwrap();
 
-    // Read commands from stdin
     let stdin = io::stdin();
     for line in stdin.lock().lines() {
         let line = match line {
@@ -196,14 +211,11 @@ fn cmd_watch(agent: &BambuAgent, device_id: &str) {
         }
 
         if line == "status" {
-            // Drain any stale messages
             agent.drain_messages();
 
-            // Send pushall
             let pushall = r#"{"pushing":{"sequence_id":"0","command":"pushall","version":1,"push_target":1}}"#;
             agent.send_message(device_id, pushall);
 
-            // Wait for full status
             let start = std::time::Instant::now();
             let timeout = Duration::from_secs(10);
             loop {
@@ -237,11 +249,11 @@ fn cmd_watch(agent: &BambuAgent, device_id: &str) {
     }
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let cli = Cli::parse();
 
-    // Set up tracing
-    let level = if cli.verbose { "debug" } else { "warn" };
+    let level = if cli.verbose { "debug" } else { "info" };
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -259,8 +271,6 @@ fn main() {
             let creds = load_credentials(credentials);
             let agent = init_agent(&cli.lib_path, &creds);
             cmd_status(&agent, device_id);
-            // Fast exit — _exit() skips atexit handlers, avoids .so MQTT
-            // thread cleanup hangs (same as C++ bridge's fast_exit).
             fast_exit(0);
         }
         Command::Watch {
@@ -272,6 +282,39 @@ fn main() {
             let agent = init_agent(&cli.lib_path, &creds);
             cmd_watch(&agent, device_id);
             fast_exit(0);
+        }
+        Command::Daemon {
+            credentials,
+            port,
+            bind,
+        } => {
+            suppress_stdout();
+            let creds = load_credentials(credentials);
+            let agent = init_agent(&cli.lib_path, &creds);
+            restore_stdout();
+
+            let state = server::AppState::new(agent);
+            let app = server::router(state);
+
+            let addr: SocketAddr = format!("{bind}:{port}")
+                .parse()
+                .unwrap_or_else(|e| {
+                    eprintln!("error: invalid bind address: {e}");
+                    process::exit(1);
+                });
+
+            tracing::info!("listening on http://{addr}");
+
+            let listener = tokio::net::TcpListener::bind(addr).await.unwrap_or_else(|e| {
+                eprintln!("error: cannot bind {addr}: {e}");
+                process::exit(1);
+            });
+            axum::serve(listener, app)
+                .await
+                .unwrap_or_else(|e| {
+                    eprintln!("error: server failed: {e}");
+                    process::exit(1);
+                });
         }
     }
 }

--- a/bridge/src/server.rs
+++ b/bridge/src/server.rs
@@ -1,0 +1,361 @@
+//! axum HTTP server exposing printer status over HTTP.
+//!
+//! Endpoints:
+//!   GET  /health            — daemon health + MQTT connection state
+//!   GET  /status/:device_id — cached printer status (instant) or live query
+//!   GET  /ams/:device_id    — AMS tray info extracted from cached status
+//!   POST /cancel/:device_id — cancel current print
+//!   WS   /watch/:device_id  — (Phase 2b, not yet implemented)
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, RwLock};
+use std::time::{Duration, Instant};
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::Json;
+use axum::routing::get;
+use axum::Router;
+use serde::{Deserialize, Serialize};
+
+use crate::agent::BambuAgent;
+
+// ---------------------------------------------------------------------------
+// Shared state
+// ---------------------------------------------------------------------------
+
+/// Cached status for a single device.
+#[derive(Clone)]
+pub struct DeviceStatus {
+    pub payload: serde_json::Value,
+    pub updated_at: Instant,
+}
+
+/// Shared state across all HTTP handlers.
+pub struct AppState {
+    /// The FFI agent (behind Mutex because it's not Sync).
+    pub agent: Mutex<BambuAgent>,
+    /// Cached printer status per device_id.
+    pub cache: RwLock<HashMap<String, DeviceStatus>>,
+    /// When the daemon started.
+    pub started_at: Instant,
+}
+
+pub type SharedState = Arc<AppState>;
+
+impl AppState {
+    pub fn new(agent: BambuAgent) -> SharedState {
+        Arc::new(Self {
+            agent: Mutex::new(agent),
+            cache: RwLock::new(HashMap::new()),
+            started_at: Instant::now(),
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize, Deserialize)]
+pub struct HealthResponse {
+    pub status: String,
+    pub mqtt_connected: bool,
+    pub uptime_secs: u64,
+    pub cached_devices: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct ErrorResponse {
+    pub error: String,
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+async fn health(State(state): State<SharedState>) -> Json<HealthResponse> {
+    let agent = state.agent.lock().unwrap();
+    let mqtt_connected = agent
+        .callback_state()
+        .server_connected
+        .load(std::sync::atomic::Ordering::SeqCst);
+    let cached_devices: Vec<String> = state
+        .cache
+        .read()
+        .unwrap()
+        .keys()
+        .cloned()
+        .collect();
+
+    Json(HealthResponse {
+        status: "ok".into(),
+        mqtt_connected,
+        uptime_secs: state.started_at.elapsed().as_secs(),
+        cached_devices,
+    })
+}
+
+async fn get_status(
+    State(state): State<SharedState>,
+    Path(device_id): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+    // Check cache first — return if fresh (< 30s old)
+    {
+        let cache = state.cache.read().unwrap();
+        if let Some(cached) = cache.get(&device_id) {
+            if cached.updated_at.elapsed() < Duration::from_secs(30) {
+                return Ok(Json(cached.payload.clone()));
+            }
+        }
+    }
+
+    // Cache miss or stale — do a live query
+    let payload = {
+        let agent = state.agent.lock().unwrap();
+
+        // Drain stale messages
+        agent.drain_messages();
+
+        if let Err(e) = agent.subscribe_and_pushall(&device_id, Duration::from_secs(10)) {
+            return Err((
+                StatusCode::BAD_GATEWAY,
+                Json(ErrorResponse {
+                    error: format!("MQTT query failed: {e}"),
+                }),
+            ));
+        }
+
+        let messages = agent.drain_messages();
+        let best = messages.iter().max_by_key(|m| m.payload.len());
+
+        match best {
+            Some(msg) => {
+                let value: serde_json::Value =
+                    serde_json::from_str(&msg.payload).unwrap_or_else(|_| {
+                        serde_json::json!({"raw": msg.payload})
+                    });
+                value
+            }
+            None => {
+                return Err((
+                    StatusCode::GATEWAY_TIMEOUT,
+                    Json(ErrorResponse {
+                        error: format!("no status received from {device_id}"),
+                    }),
+                ));
+            }
+        }
+    };
+
+    // Update cache
+    {
+        let mut cache = state.cache.write().unwrap();
+        cache.insert(
+            device_id,
+            DeviceStatus {
+                payload: payload.clone(),
+                updated_at: Instant::now(),
+            },
+        );
+    }
+
+    Ok(Json(payload))
+}
+
+async fn get_ams(
+    State(state): State<SharedState>,
+    Path(device_id): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+    // Get status first (uses cache)
+    let status = get_status(State(state), Path(device_id)).await?;
+    let value = status.0;
+
+    // Extract AMS data from the status
+    let print_data = value.get("print").unwrap_or(&value);
+    let ams = print_data.get("ams");
+    let vt_tray = print_data.get("vt_tray");
+
+    match ams {
+        Some(ams_data) => {
+            let mut result = serde_json::json!({ "ams": ams_data });
+            if let Some(vt) = vt_tray {
+                result["vt_tray"] = vt.clone();
+            }
+            Ok(Json(result))
+        }
+        None => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: "no AMS data in printer status".into(),
+            }),
+        )),
+    }
+}
+
+async fn cancel_print(
+    State(state): State<SharedState>,
+    Path(device_id): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+    let agent = state.agent.lock().unwrap();
+    let stop_cmd = r#"{"print":{"command":"stop","sequence_id":"0"}}"#;
+    let ret = agent.send_message(&device_id, stop_cmd);
+
+    if ret != 0 {
+        return Err((
+            StatusCode::BAD_GATEWAY,
+            Json(ErrorResponse {
+                error: format!("send_message returned {ret}"),
+            }),
+        ));
+    }
+
+    Ok(Json(serde_json::json!({
+        "command": "stop",
+        "device_id": device_id,
+        "sent": true,
+    })))
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+/// Build an AppState with pre-populated cache (for testing without FFI).
+#[cfg(test)]
+pub fn mock_state(devices: HashMap<String, serde_json::Value>) -> SharedState {
+    // We can't create a real BambuAgent without the .so, so we use a test-only
+    // constructor. The agent field won't be accessed in tests that only hit cache.
+    let state = Arc::new(AppState {
+        agent: Mutex::new(unsafe { BambuAgent::test_null() }),
+        cache: RwLock::new(
+            devices
+                .into_iter()
+                .map(|(k, v)| {
+                    (
+                        k,
+                        DeviceStatus {
+                            payload: v,
+                            updated_at: Instant::now(),
+                        },
+                    )
+                })
+                .collect(),
+        ),
+        started_at: Instant::now(),
+    });
+    state
+}
+
+pub fn router(state: SharedState) -> Router {
+    Router::new()
+        .route("/health", get(health))
+        .route("/status/:device_id", get(get_status))
+        .route("/ams/:device_id", get(get_ams))
+        .route("/cancel/:device_id", axum::routing::post(cancel_print))
+        .with_state(state)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_status() -> serde_json::Value {
+        serde_json::json!({
+            "print": {
+                "gcode_state": "RUNNING",
+                "bed_temper": 60.0,
+                "nozzle_temper": 220.0,
+                "subtask_name": "test_cube",
+                "ams": {
+                    "ams": [{
+                        "id": "0",
+                        "tray": [
+                            {"id": "0", "tray_type": "PLA", "tray_color": "FFFFFFFF"},
+                            {"id": "1", "tray_type": "ASA", "tray_color": "BCBCBCFF"},
+                        ]
+                    }]
+                },
+                "vt_tray": {"id": "254", "tray_type": "TPU"}
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn health_returns_ok() {
+        let state = mock_state(HashMap::new());
+        let app = router(state);
+        let server = axum_test::TestServer::new(app).unwrap();
+
+        let resp = server.get("/health").await;
+        resp.assert_status_ok();
+        let body: HealthResponse = resp.json();
+        assert_eq!(body.status, "ok");
+        assert!(!body.mqtt_connected);
+        assert!(body.cached_devices.is_empty());
+    }
+
+    #[tokio::test]
+    async fn health_shows_cached_devices() {
+        let mut devices = HashMap::new();
+        devices.insert("DEV001".into(), sample_status());
+        let state = mock_state(devices);
+        let app = router(state);
+        let server = axum_test::TestServer::new(app).unwrap();
+
+        let resp = server.get("/health").await;
+        let body: HealthResponse = resp.json();
+        assert_eq!(body.cached_devices, vec!["DEV001"]);
+    }
+
+    #[tokio::test]
+    async fn status_returns_cached() {
+        let mut devices = HashMap::new();
+        devices.insert("DEV001".into(), sample_status());
+        let state = mock_state(devices);
+        let app = router(state);
+        let server = axum_test::TestServer::new(app).unwrap();
+
+        let resp = server.get("/status/DEV001").await;
+        resp.assert_status_ok();
+        let body: serde_json::Value = resp.json();
+        assert_eq!(body["print"]["gcode_state"], "RUNNING");
+        assert_eq!(body["print"]["subtask_name"], "test_cube");
+    }
+
+    #[tokio::test]
+    async fn ams_extracts_from_cached_status() {
+        let mut devices = HashMap::new();
+        devices.insert("DEV001".into(), sample_status());
+        let state = mock_state(devices);
+        let app = router(state);
+        let server = axum_test::TestServer::new(app).unwrap();
+
+        let resp = server.get("/ams/DEV001").await;
+        resp.assert_status_ok();
+        let body: serde_json::Value = resp.json();
+        let trays = &body["ams"]["ams"][0]["tray"];
+        assert_eq!(trays[0]["tray_type"], "PLA");
+        assert_eq!(trays[1]["tray_type"], "ASA");
+        assert_eq!(body["vt_tray"]["tray_type"], "TPU");
+    }
+
+    #[tokio::test]
+    async fn ams_returns_404_when_no_ams_data() {
+        let mut devices = HashMap::new();
+        devices.insert(
+            "DEV002".into(),
+            serde_json::json!({"print": {"gcode_state": "IDLE"}}),
+        );
+        let state = mock_state(devices);
+        let app = router(state);
+        let server = axum_test::TestServer::new(app).unwrap();
+
+        let resp = server.get("/ams/DEV002").await;
+        resp.assert_status(StatusCode::NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## Summary

- HTTP daemon (`bambu-bridge daemon`) exposing printer operations over localhost HTTP
- 20 unit tests covering credentials, callbacks, and HTTP handlers — all run without the `.so`
- Builds on Phase 1 (merged in #3)

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | `/health` | MQTT connection state, uptime, cached devices |
| GET | `/status/:device_id` | Cached status (30s TTL) or live MQTT query |
| GET | `/ams/:device_id` | AMS tray info from cached status |
| POST | `/cancel/:device_id` | Cancel current print |

Binds to `127.0.0.1:8765` by default (localhost only).

## Usage

```bash
# Start daemon
bambu-bridge daemon credentials.toml --port 8765

# Query from Python / curl
curl http://localhost:8765/health
curl http://localhost:8765/status/01P00A451601106
curl http://localhost:8765/ams/01P00A451601106
curl -X POST http://localhost:8765/cancel/01P00A451601106
```

## Tests (20 passing)

- **Credentials** (7): JSON/TOML parsing, missing fields, fallback behavior, user_json structure
- **CallbackState** (8): atomic flags, message buffer drain, callback functions with FFI types
- **HTTP handlers** (5): health, cached status, AMS extraction, 404 on missing AMS

```
running 20 tests ... test result: ok. 20 passed; 0 failed
```

## Test plan

- [x] `cargo test` — 20 unit tests pass without .so
- [ ] `cargo build --release` + `bambu-bridge daemon` against P1S
- [ ] `curl /status/:device` returns same data as Phase 1 CLI
- [ ] `curl /ams/:device` extracts AMS tray info correctly
- [ ] Cache returns instant response on second request

🤖 Generated with [Claude Code](https://claude.com/claude-code)