### PR TITLE
Add /print endpoint with bridge.py cloud_print replication

### DIFF
--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -3,6 +3,23 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,6 +83,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "assert-json-diff"
@@ -156,6 +182,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c794b30c904f0a1c2fb7740f7df7f7972dfaa14ef6f57cb6178dc63e5dca2f04"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "fastrand",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "multer",
+ "pin-project-lite",
+ "serde",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "axum-test"
 version = "16.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,17 +239,21 @@ name = "bambu-bridge"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "axum-extra",
  "axum-test",
  "cc",
  "clap",
  "libc",
+ "roxmltree",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "toml",
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "zip",
 ]
 
 [[package]]
@@ -208,6 +261,27 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -222,12 +296,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
 
 [[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -236,6 +331,16 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "clap"
@@ -284,6 +389,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +403,61 @@ dependencies = [
  "time",
  "version_check",
 ]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
 name = "deranged"
@@ -303,10 +469,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "displaydoc"
@@ -317,6 +505,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -336,16 +533,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -398,6 +617,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,6 +635,42 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -419,6 +684,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -600,6 +874,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,7 +907,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -643,16 +934,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -674,6 +997,27 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "matchers"
@@ -713,6 +1057,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +1075,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.4.0",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -774,6 +1145,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +1165,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "potential_utf"
@@ -820,6 +1207,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,6 +1233,18 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -864,7 +1273,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -903,6 +1312,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
 name = "rust-multipart-rfc7578_2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,6 +1331,19 @@ dependencies = [
  "mime_guess",
  "rand",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -935,6 +1363,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1012,6 +1446,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,6 +1482,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,6 +1510,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1526,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1096,6 +1559,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1370,6 +1846,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,6 +1862,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"
@@ -1433,6 +1921,103 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,10 +2042,107 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
 
 [[package]]
 name = "yansi"
@@ -1533,6 +2215,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,7 +2268,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "thiserror 2.0.18",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -13,7 +13,11 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 toml = "0.8"
+tempfile = "3"
+zip = "2"
+roxmltree = "0.20"
 tower-http = { version = "0.6", features = ["cors", "trace"] }
+axum-extra = { version = "0.9", features = ["multipart"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/bridge/shim/shim.cpp
+++ b/bridge/shim/shim.cpp
@@ -18,6 +18,9 @@
 // Type definitions matching bambu_networking.hpp
 // ---------------------------------------------------------------------------
 
+typedef std::function<void(int status, int code, std::string msg)> OnUpdateStatusFn;
+typedef std::function<bool()> WasCancelledFn;
+typedef std::function<bool(int status, std::string job_info)> OnWaitFn;
 typedef std::function<void(int online_login, bool login)> OnUserLoginFn;
 typedef std::function<void(std::string topic_str)> OnPrinterConnectedFn;
 typedef std::function<void(int return_code, int reason_code)> OnServerConnectedFn;
@@ -25,6 +28,51 @@ typedef std::function<void(unsigned http_code, std::string http_body)> OnHttpErr
 typedef std::function<std::string()> GetCountryCodeFn;
 typedef std::function<void(std::string topic)> GetSubscribeFailureFn;
 typedef std::function<void(std::string dev_id, std::string msg)> OnMessageFn;
+
+struct PrintParams {
+    std::string dev_id;
+    std::string task_name;
+    std::string project_name;
+    std::string preset_name;
+    std::string filename;
+    std::string config_filename;
+    int         plate_index;
+    std::string ftp_folder;
+    std::string ftp_file;
+    std::string ftp_file_md5;
+    std::string nozzle_mapping;
+    std::string ams_mapping;
+    std::string ams_mapping2;
+    std::string ams_mapping_info;
+    std::string nozzles_info;
+    std::string connection_type;
+    std::string comments;
+    int         origin_profile_id = 0;
+    int         stl_design_id = 0;
+    std::string origin_model_id;
+    std::string print_type;
+    std::string dst_file;
+    std::string dev_name;
+    std::string dev_ip;
+    bool        use_ssl_for_ftp;
+    bool        use_ssl_for_mqtt;
+    std::string username;
+    std::string password;
+    bool        task_bed_leveling;
+    bool        task_flow_cali;
+    bool        task_vibration_cali;
+    bool        task_layer_inspect;
+    bool        task_record_timelapse;
+    bool        task_use_ams;
+    std::string task_bed_type;
+    std::string extra_options;
+    int         auto_bed_leveling{0};
+    int         auto_flow_cali{0};
+    int         auto_offset_cali{0};
+    int         extruder_cali_manual_mode{-1};
+    bool        task_ext_change_assist;
+    bool        try_emmc_print;
+};
 
 // ---------------------------------------------------------------------------
 // Function pointer types (resolved via dlsym)
@@ -53,6 +101,7 @@ typedef int (*fn_set_extra_http_header)(void*, std::map<std::string, std::string
 typedef int (*fn_send_message)(void*, std::string, std::string, int);
 typedef int (*fn_send_message_to_printer)(void*, std::string, std::string, int, int);
 typedef int (*fn_start_subscribe)(void*, std::string);
+typedef int (*fn_start_print)(void*, PrintParams, OnUpdateStatusFn, WasCancelledFn, OnWaitFn);
 
 // ---------------------------------------------------------------------------
 // Resolved function pointers
@@ -83,6 +132,7 @@ static fn_set_extra_http_header     fp_set_extra_hdr = nullptr;
 static fn_send_message              fp_send_msg = nullptr;
 static fn_send_message_to_printer   fp_send_msg_printer = nullptr;
 static fn_start_subscribe           fp_start_sub = nullptr;
+static fn_start_print               fp_start_print = nullptr;
 
 // ---------------------------------------------------------------------------
 // Helper
@@ -129,6 +179,7 @@ int bambu_shim_load(const char* lib_path) {
     fp_send_msg        = load_fn<fn_send_message>("bambu_network_send_message");
     fp_send_msg_printer = load_fn<fn_send_message_to_printer>("bambu_network_send_message_to_printer");
     fp_start_sub       = load_fn<fn_start_subscribe>("bambu_network_start_subscribe");
+    fp_start_print     = load_fn<fn_start_print>("bambu_network_start_print");
 
     if (!fp_create_agent || !fp_change_user || !fp_connect_server) {
         dlclose(g_lib);
@@ -351,6 +402,118 @@ int bambu_shim_set_on_subscribe_failure_fn(
         if (g_sub_fail_cb) g_sub_fail_cb(topic.c_str(), g_sub_fail_cb_ctx);
     };
     return fp_set_sub_fail_cb(agent, wrapper);
+}
+
+// ---------------------------------------------------------------------------
+// Print support
+// ---------------------------------------------------------------------------
+
+// C-compatible PrintParams (all const char* instead of std::string)
+struct BambuShimPrintParams {
+    const char* dev_id;
+    const char* task_name;
+    const char* project_name;
+    const char* preset_name;
+    const char* filename;
+    const char* config_filename;
+    int         plate_index;
+    const char* ftp_folder;
+    const char* ams_mapping;
+    const char* ams_mapping2;
+    const char* ams_mapping_info;
+    const char* connection_type;
+    const char* print_type;
+    int         task_bed_leveling;
+    int         task_flow_cali;
+    int         task_vibration_cali;
+    int         task_layer_inspect;
+    int         task_record_timelapse;
+    int         task_use_ams;
+    const char* task_bed_type;
+};
+
+// Print progress callback: (stage, code, msg, ctx)
+typedef void (*shim_on_print_progress_fn)(int, int, const char*, void*);
+
+// Result struct filled by start_print
+struct BambuShimPrintResult {
+    int return_code;    // from fp_start_print
+    int print_result;   // from the completion callback (-999 = never fired)
+    int finished;       // 1 if completion callback fired
+};
+
+int bambu_shim_start_print(
+    void* agent,
+    const BambuShimPrintParams* p,
+    shim_on_print_progress_fn progress_cb,
+    void* progress_ctx,
+    BambuShimPrintResult* result
+) {
+    if (!fp_start_print) return -1;
+
+    // Convert C params to C++ PrintParams
+    PrintParams params;
+    params.dev_id            = p->dev_id ? p->dev_id : "";
+    params.task_name         = p->task_name ? p->task_name : "";
+    params.project_name      = p->project_name ? p->project_name : "";
+    params.preset_name       = p->preset_name ? p->preset_name : "";
+    params.filename          = p->filename ? p->filename : "";
+    params.config_filename   = p->config_filename ? p->config_filename : "";
+    params.plate_index       = p->plate_index;
+    params.ftp_folder        = p->ftp_folder ? p->ftp_folder : "sdcard/";
+    params.ftp_file          = "";
+    params.ftp_file_md5      = "";
+    params.nozzle_mapping    = "[]";
+    params.ams_mapping       = p->ams_mapping ? p->ams_mapping : "[0,1,2,3]";
+    params.ams_mapping2      = p->ams_mapping2 ? p->ams_mapping2 : "";
+    params.ams_mapping_info  = p->ams_mapping_info ? p->ams_mapping_info : "";
+    params.nozzles_info      = "";
+    params.connection_type   = p->connection_type ? p->connection_type : "cloud";
+    params.comments          = "";
+    params.origin_profile_id = 0;
+    params.stl_design_id     = 0;
+    params.origin_model_id   = "";
+    params.print_type        = p->print_type ? p->print_type : "from_normal";
+    params.dst_file          = "";
+    params.dev_name          = "";
+    params.dev_ip            = "";
+    params.use_ssl_for_ftp   = false;
+    params.use_ssl_for_mqtt  = true;
+    params.username          = "";
+    params.password          = "";
+    params.task_bed_leveling     = p->task_bed_leveling != 0;
+    params.task_flow_cali        = p->task_flow_cali != 0;
+    params.task_vibration_cali   = p->task_vibration_cali != 0;
+    params.task_layer_inspect    = p->task_layer_inspect != 0;
+    params.task_record_timelapse = p->task_record_timelapse != 0;
+    params.task_use_ams          = p->task_use_ams != 0;
+    params.task_bed_type         = p->task_bed_type ? p->task_bed_type : "auto";
+    params.extra_options         = "";
+    params.auto_bed_leveling     = 0;
+    params.auto_flow_cali        = 0;
+    params.auto_offset_cali      = 0;
+    params.extruder_cali_manual_mode = -1;
+    params.task_ext_change_assist = false;
+    params.try_emmc_print         = false;
+
+    // Track result
+    result->print_result = -999;
+    result->finished = 0;
+
+    OnUpdateStatusFn update_fn = [progress_cb, progress_ctx, result](
+        int status, int code, std::string msg
+    ) {
+        if (progress_cb)
+            progress_cb(status, code, msg.c_str(), progress_ctx);
+        if (status == 6) { result->print_result = 0; result->finished = 1; }
+        else if (status == 7) { result->print_result = code; result->finished = 1; }
+    };
+
+    WasCancelledFn cancel_fn = []() -> bool { return false; };
+    OnWaitFn wait_fn = [](int, std::string) -> bool { return false; };
+
+    result->return_code = fp_start_print(agent, params, update_fn, cancel_fn, wait_fn);
+    return 0;
 }
 
 } // extern "C"

--- a/bridge/src/agent.rs
+++ b/bridge/src/agent.rs
@@ -12,6 +12,67 @@ use std::time::Duration;
 use crate::callbacks::{self, CallbackState};
 use crate::ffi;
 
+/// Print job request parameters.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct PrintRequest {
+    pub device_id: String,
+    pub filename: String,
+    #[serde(default = "default_project_name")]
+    pub project_name: String,
+    pub config_filename: Option<String>,
+    pub ams_mapping: Option<String>,
+    pub ams_mapping2: Option<String>,
+    #[serde(default = "default_true")]
+    pub bed_leveling: bool,
+    #[serde(default = "default_true")]
+    pub flow_cali: bool,
+    #[serde(default = "default_true")]
+    pub vibration_cali: bool,
+    #[serde(default)]
+    pub timelapse: bool,
+    #[serde(default = "default_true")]
+    pub use_ams: bool,
+}
+
+fn default_project_name() -> String {
+    "bambu-3mf".into()
+}
+fn default_true() -> bool {
+    true
+}
+
+/// Result from a print job.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct PrintResult {
+    pub result: String,
+    pub return_code: i32,
+    pub print_result: i32,
+    pub device_id: String,
+    pub file: String,
+}
+
+/// FFI callback for print progress (logged only).
+extern "C" fn print_progress_callback(
+    stage: std::os::raw::c_int,
+    code: std::os::raw::c_int,
+    msg: *const std::os::raw::c_char,
+    _ctx: *mut std::os::raw::c_void,
+) {
+    static STAGE_NAMES: &[&str] = &[
+        "Create", "Upload", "Waiting", "Sending",
+        "Record", "WaitPrinter", "Finished", "ERROR", "Limit",
+    ];
+    let stage_name = STAGE_NAMES
+        .get(stage as usize)
+        .unwrap_or(&"?");
+    let msg_str = if msg.is_null() {
+        ""
+    } else {
+        unsafe { std::ffi::CStr::from_ptr(msg).to_str().unwrap_or("") }
+    };
+    tracing::info!(stage = stage_name, code, msg = msg_str, "print progress");
+}
+
 /// Credentials loaded from `credentials.toml` or a token JSON file.
 #[derive(Debug)]
 pub struct Credentials {
@@ -125,6 +186,14 @@ impl BambuAgent {
                 }
             };
             return Err(format!("failed to load library: {err}"));
+        }
+
+        // Set SSL cert env vars (same as C++ bridge) — needed for uploads
+        if std::env::var("CURL_CA_BUNDLE").is_err() {
+            std::env::set_var("CURL_CA_BUNDLE", "/etc/ssl/certs/ca-certificates.crt");
+        }
+        if std::env::var("SSL_CERT_FILE").is_err() {
+            std::env::set_var("SSL_CERT_FILE", "/etc/ssl/certs/ca-certificates.crt");
         }
 
         // Create directories the .so expects
@@ -373,6 +442,104 @@ impl BambuAgent {
         ret
     }
 
+    /// Start a cloud print job. Subscribes, sends pushall, then calls start_print.
+    /// Retries up to 5 times on enc-flag-not-ready (-3140).
+    pub fn start_print(
+        &self,
+        params: &PrintRequest,
+    ) -> Result<PrintResult, String> {
+        // Subscribe and wait for MQTT readiness
+        self.subscribe_and_pushall(&params.device_id, Duration::from_secs(20))?;
+
+        // Build C-compatible params — keep CStrings alive for the duration
+        let dev_id = CString::new(params.device_id.as_str()).unwrap();
+        let task_name = CString::new("").unwrap();
+        let project_name = CString::new(params.project_name.as_str()).unwrap();
+        let preset_name = CString::new("").unwrap();
+        let filename = CString::new(params.filename.as_str()).unwrap();
+        let config_filename = CString::new(params.config_filename.as_deref().unwrap_or("")).unwrap();
+        let ftp_folder = CString::new("sdcard/").unwrap();
+        let ams_mapping = CString::new(params.ams_mapping.as_deref().unwrap_or("[0,1,2,3]")).unwrap();
+        let ams_mapping2 = CString::new(params.ams_mapping2.as_deref().unwrap_or("")).unwrap();
+        let ams_mapping_info = CString::new("").unwrap();
+        let connection_type = CString::new("cloud").unwrap();
+        let print_type = CString::new("from_normal").unwrap();
+        let bed_type = CString::new("auto").unwrap();
+
+        let shim_params = ffi::ShimPrintParams {
+            dev_id: dev_id.as_ptr(),
+            task_name: task_name.as_ptr(),
+            project_name: project_name.as_ptr(),
+            preset_name: preset_name.as_ptr(),
+            filename: filename.as_ptr(),
+            config_filename: config_filename.as_ptr(),
+            plate_index: 1,
+            ftp_folder: ftp_folder.as_ptr(),
+            ams_mapping: ams_mapping.as_ptr(),
+            ams_mapping2: ams_mapping2.as_ptr(),
+            ams_mapping_info: ams_mapping_info.as_ptr(),
+            connection_type: connection_type.as_ptr(),
+            print_type: print_type.as_ptr(),
+            task_bed_leveling: if params.bed_leveling { 1 } else { 0 },
+            task_flow_cali: if params.flow_cali { 1 } else { 0 },
+            task_vibration_cali: if params.vibration_cali { 1 } else { 0 },
+            task_layer_inspect: 0,
+            task_record_timelapse: if params.timelapse { 1 } else { 0 },
+            task_use_ams: if params.use_ams { 1 } else { 0 },
+            task_bed_type: bed_type.as_ptr(),
+        };
+
+        let mut result = ffi::ShimPrintResult {
+            return_code: -999,
+            print_result: -999,
+            finished: 0,
+        };
+
+        // Retry on enc flag not ready (-3140)
+        for attempt in 0..5 {
+            result.print_result = -999;
+            result.finished = 0;
+
+            let ret = unsafe {
+                ffi::bambu_shim_start_print(
+                    self.agent,
+                    &shim_params,
+                    print_progress_callback,
+                    std::ptr::null_mut(),
+                    &mut result,
+                )
+            };
+
+            if ret != 0 {
+                return Err(format!("shim_start_print returned {ret}"));
+            }
+
+            tracing::info!(attempt = attempt + 1, return_code = result.return_code, "start_print");
+
+            if result.return_code != -3140 {
+                break;
+            }
+            tracing::warn!("enc flag not ready, retrying in 15s...");
+            let pushall = r#"{"pushing":{"sequence_id":"0","command":"pushall","version":1,"push_target":1}}"#;
+            self.send_message(&params.device_id, pushall);
+            std::thread::sleep(Duration::from_secs(15));
+        }
+
+        let status = match result.return_code {
+            0 => "success",
+            -1 => "sent",
+            _ => "error",
+        };
+
+        Ok(PrintResult {
+            result: status.into(),
+            return_code: result.return_code,
+            print_result: result.print_result,
+            device_id: params.device_id.clone(),
+            file: params.filename.clone(),
+        })
+    }
+
     /// Drain all buffered MQTT messages.
     pub fn drain_messages(&self) -> Vec<callbacks::MqttMessage> {
         self.state.drain_messages()
@@ -495,6 +662,67 @@ email = "user@example.com"
         assert_eq!(v["data"]["user"]["uid"], "u");
         assert_eq!(v["data"]["user"]["name"], "n");
         assert_eq!(v["data"]["user"]["account"], "e");
+    }
+
+    #[test]
+    fn print_request_deserialize_minimal() {
+        let json = r#"{"device_id":"DEV1","filename":"test.3mf"}"#;
+        let req: PrintRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.device_id, "DEV1");
+        assert_eq!(req.filename, "test.3mf");
+        assert_eq!(req.project_name, "bambu-3mf");
+        assert!(req.bed_leveling);
+        assert!(req.flow_cali);
+        assert!(req.vibration_cali);
+        assert!(!req.timelapse);
+        assert!(req.use_ams);
+        assert!(req.ams_mapping.is_none());
+        assert!(req.config_filename.is_none());
+    }
+
+    #[test]
+    fn print_request_deserialize_full() {
+        let json = r#"{
+            "device_id": "DEV1",
+            "filename": "cube.3mf",
+            "project_name": "my-project",
+            "config_filename": "cube_config.3mf",
+            "ams_mapping": "[0,1]",
+            "ams_mapping2": "[{\"ams_id\":0,\"slot_id\":0}]",
+            "bed_leveling": false,
+            "flow_cali": false,
+            "vibration_cali": false,
+            "timelapse": true,
+            "use_ams": false
+        }"#;
+        let req: PrintRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.project_name, "my-project");
+        assert_eq!(req.config_filename.as_deref(), Some("cube_config.3mf"));
+        assert_eq!(req.ams_mapping.as_deref(), Some("[0,1]"));
+        assert!(!req.bed_leveling);
+        assert!(req.timelapse);
+        assert!(!req.use_ams);
+    }
+
+    #[test]
+    fn print_request_serialize_roundtrip() {
+        let req = PrintRequest {
+            device_id: "DEV".into(),
+            filename: "f.3mf".into(),
+            project_name: "p".into(),
+            config_filename: None,
+            ams_mapping: None,
+            ams_mapping2: None,
+            bed_leveling: true,
+            flow_cali: true,
+            vibration_cali: true,
+            timelapse: false,
+            use_ams: true,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let req2: PrintRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(req2.device_id, "DEV");
+        assert_eq!(req2.filename, "f.3mf");
     }
 
     #[test]

--- a/bridge/src/ffi.rs
+++ b/bridge/src/ffi.rs
@@ -5,6 +5,42 @@
 
 use std::os::raw::{c_char, c_int, c_uint, c_void};
 
+// C-compatible PrintParams matching BambuShimPrintParams in shim.cpp
+#[repr(C)]
+pub struct ShimPrintParams {
+    pub dev_id: *const c_char,
+    pub task_name: *const c_char,
+    pub project_name: *const c_char,
+    pub preset_name: *const c_char,
+    pub filename: *const c_char,
+    pub config_filename: *const c_char,
+    pub plate_index: c_int,
+    pub ftp_folder: *const c_char,
+    pub ams_mapping: *const c_char,
+    pub ams_mapping2: *const c_char,
+    pub ams_mapping_info: *const c_char,
+    pub connection_type: *const c_char,
+    pub print_type: *const c_char,
+    pub task_bed_leveling: c_int,
+    pub task_flow_cali: c_int,
+    pub task_vibration_cali: c_int,
+    pub task_layer_inspect: c_int,
+    pub task_record_timelapse: c_int,
+    pub task_use_ams: c_int,
+    pub task_bed_type: *const c_char,
+}
+
+#[repr(C)]
+pub struct ShimPrintResult {
+    pub return_code: c_int,
+    pub print_result: c_int,
+    pub finished: c_int,
+}
+
+// Print progress callback type
+pub type OnPrintProgressFn =
+    extern "C" fn(stage: c_int, code: c_int, msg: *const c_char, ctx: *mut c_void);
+
 // Callback function pointer types matching shim.cpp typedefs
 pub type OnServerConnectedFn = extern "C" fn(rc: c_int, reason: c_int, ctx: *mut c_void);
 pub type OnMessageFn = extern "C" fn(dev_id: *const c_char, msg: *const c_char, ctx: *mut c_void);
@@ -101,5 +137,14 @@ extern "C" {
         agent: *mut c_void,
         cb: OnSubscribeFailureFn,
         ctx: *mut c_void,
+    ) -> c_int;
+
+    // Print
+    pub fn bambu_shim_start_print(
+        agent: *mut c_void,
+        params: *const ShimPrintParams,
+        progress_cb: OnPrintProgressFn,
+        progress_ctx: *mut c_void,
+        result: *mut ShimPrintResult,
     ) -> c_int;
 }

--- a/bridge/src/main.rs
+++ b/bridge/src/main.rs
@@ -6,6 +6,7 @@
 mod agent;
 mod callbacks;
 mod ffi;
+mod print_job;
 mod server;
 
 use std::io::{self, BufRead, Write};

--- a/bridge/src/print_job.rs
+++ b/bridge/src/print_job.rs
@@ -1,0 +1,574 @@
+//! Print job preparation — replicates the battle-tested Python bridge.py logic.
+//!
+//! This module handles:
+//! - Config-only 3MF generation (strip gcode, images, MD5)
+//! - AMS tray parsing from printer status
+//! - AMS mapping (match virtual filament slots to physical trays)
+//! - Config 3MF color patching to match AMS tray colors
+//!
+//! Ported from `src/bambu_3mf/bridge.py` — preserving exact behavior.
+
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::io::{Cursor, Read, Write};
+
+// ---------------------------------------------------------------------------
+// AMS tray parsing (mirrors parse_ams_trays in bridge.py)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AmsTray {
+    pub phys_slot: i32,
+    pub ams_id: i32,
+    pub slot_id: i32,
+    #[serde(rename = "type")]
+    pub tray_type: String,
+    pub color: String,
+    pub tray_info_idx: String,
+}
+
+/// Extract physical AMS tray info from a printer status dict.
+/// Mirrors `parse_ams_trays()` in bridge.py.
+pub fn parse_ams_trays(status: &serde_json::Value) -> Vec<AmsTray> {
+    let mut trays = Vec::new();
+    let ams_data = match status.get("ams") {
+        Some(v) => v,
+        None => return trays,
+    };
+    let units = match ams_data.get("ams").and_then(|v| v.as_array()) {
+        Some(a) => a,
+        None => return trays,
+    };
+
+    for unit in units {
+        let ams_id = unit
+            .get("id")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<i32>().ok())
+            .or_else(|| unit.get("id").and_then(|v| v.as_i64()).map(|n| n as i32))
+            .unwrap_or(0);
+
+        let unit_trays = match unit.get("tray").and_then(|v| v.as_array()) {
+            Some(a) => a,
+            None => continue,
+        };
+
+        for tray in unit_trays {
+            let slot_id = tray
+                .get("id")
+                .and_then(|v| v.as_str())
+                .and_then(|s| s.parse::<i32>().ok())
+                .or_else(|| tray.get("id").and_then(|v| v.as_i64()).map(|n| n as i32))
+                .unwrap_or(0);
+
+            let fil_type = tray
+                .get("tray_type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if fil_type.is_empty() {
+                continue;
+            }
+
+            let color_raw = tray
+                .get("tray_color")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let color = if color_raw.len() >= 6 {
+                &color_raw[..6]
+            } else {
+                color_raw
+            };
+
+            trays.push(AmsTray {
+                phys_slot: ams_id * 4 + slot_id,
+                ams_id,
+                slot_id,
+                tray_type: fil_type.to_string(),
+                color: color.to_string(),
+                tray_info_idx: tray
+                    .get("tray_info_idx")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            });
+        }
+    }
+
+    trays
+}
+
+// ---------------------------------------------------------------------------
+// AMS mapping (mirrors _build_ams_mapping in bridge.py)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+pub struct AmsMapping {
+    #[serde(rename = "amsMapping")]
+    pub mapping: Vec<i32>,
+    #[serde(rename = "amsMapping2")]
+    pub mapping2: Vec<AmsMapping2Entry>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AmsMapping2Entry {
+    pub ams_id: i32,
+    pub slot_id: i32,
+}
+
+/// Build AMS mapping arrays from a 3MF file and live AMS tray state.
+/// Mirrors `_build_ams_mapping()` in bridge.py.
+pub fn build_ams_mapping(
+    threemf_data: &[u8],
+    ams_trays: &[AmsTray],
+) -> AmsMapping {
+    let mut total_slots = 0;
+    let mut filament_by_id: HashMap<i32, FilamentInfo> = HashMap::new();
+
+    // Parse 3MF to find filament info
+    if let Ok(mut archive) = zip::ZipArchive::new(Cursor::new(threemf_data)) {
+        // Read project_settings into a string (separate scope to release borrow)
+        let ps_text = {
+            let mut buf = String::new();
+            if let Ok(mut entry) = archive.by_name("Metadata/project_settings.config") {
+                let _ = entry.read_to_string(&mut buf);
+            }
+            buf
+        };
+        if !ps_text.is_empty() {
+            if let Ok(ps) = serde_json::from_str::<serde_json::Value>(&ps_text) {
+                if let Some(colours) = ps.get("filament_colour").and_then(|v| v.as_array()) {
+                    total_slots = colours.len();
+                }
+            }
+        }
+
+        // Read slice_info into a string (separate scope to release borrow)
+        let si_text = {
+            let mut buf = String::new();
+            if let Ok(mut entry) = archive.by_name("Metadata/slice_info.config") {
+                let _ = entry.read_to_string(&mut buf);
+            }
+            buf
+        };
+        if !si_text.is_empty() {
+            if let Ok(doc) = roxmltree::Document::parse(&si_text) {
+                if let Some(plate_el) = doc
+                    .descendants()
+                    .find(|n| n.has_tag_name("plate"))
+                {
+                    for f in plate_el.children().filter(|n| n.has_tag_name("filament")) {
+                        let fid: i32 = f
+                            .attribute("id")
+                            .and_then(|s| s.parse().ok())
+                            .unwrap_or(1);
+                        let fil_type =
+                            f.attribute("type").unwrap_or("").to_string();
+                        let color = f.attribute("color").unwrap_or("").to_string();
+                        filament_by_id.insert(fid, FilamentInfo { fil_type, color });
+                    }
+                    if total_slots == 0 && !filament_by_id.is_empty() {
+                        total_slots = *filament_by_id.keys().max().unwrap_or(&0) as usize;
+                    }
+                }
+            }
+        }
+    }
+
+    if filament_by_id.is_empty() {
+        return AmsMapping {
+            mapping: Vec::new(),
+            mapping2: Vec::new(),
+        };
+    }
+
+    // Match virtual filament slots to physical AMS trays
+    let mut mapping = vec![-1i32; total_slots];
+    let mut used: HashSet<i32> = HashSet::new();
+
+    let mut sorted_ids: Vec<i32> = filament_by_id.keys().cloned().collect();
+    sorted_ids.sort();
+
+    for filament_id in sorted_ids {
+        let f = &filament_by_id[&filament_id];
+        let idx = (filament_id - 1) as usize;
+
+        let mut best: Option<&AmsTray> = None;
+        let mut best_score = 0;
+
+        if !ams_trays.is_empty() {
+            for tray in ams_trays {
+                if used.contains(&tray.phys_slot) {
+                    continue;
+                }
+                let mut score = 0;
+                if tray.tray_type == f.fil_type {
+                    score += 2;
+                }
+                let f_color = f.color.trim_start_matches('#').to_uppercase();
+                if tray.color.to_uppercase() == f_color {
+                    score += 1;
+                }
+                if score > best_score {
+                    best_score = score;
+                    best = Some(tray);
+                }
+            }
+            // Only use if we found a match with score > 0
+            if best_score == 0 {
+                best = None;
+            }
+        }
+
+        if idx < mapping.len() {
+            if let Some(tray) = best {
+                mapping[idx] = tray.phys_slot;
+                used.insert(tray.phys_slot);
+            } else {
+                mapping[idx] = idx as i32; // fallback: identity
+            }
+        }
+    }
+
+    let mapping2: Vec<AmsMapping2Entry> = mapping
+        .iter()
+        .map(|&slot| {
+            if slot >= 0 {
+                AmsMapping2Entry {
+                    ams_id: slot / 4,
+                    slot_id: slot % 4,
+                }
+            } else {
+                AmsMapping2Entry {
+                    ams_id: 255,
+                    slot_id: 255,
+                }
+            }
+        })
+        .collect();
+
+    AmsMapping { mapping, mapping2 }
+}
+
+struct FilamentInfo {
+    fil_type: String,
+    color: String,
+}
+
+// ---------------------------------------------------------------------------
+// Config-only 3MF generation (mirrors _strip_gcode_from_3mf in bridge.py)
+// ---------------------------------------------------------------------------
+
+/// Allowed files in config-only 3MF — exact list from Python bridge.
+const ALLOWED_CONFIG_FILES: &[&str] = &[
+    "[Content_Types].xml",
+    "_rels/.rels",
+    "Metadata/slice_info.config",
+    "Metadata/model_settings.config",
+    "Metadata/project_settings.config",
+    "Metadata/_rels/model_settings.config.rels",
+];
+
+/// Create a config-only 3MF (no gcode, no images, no MD5).
+/// Mirrors `_strip_gcode_from_3mf()` in bridge.py.
+pub fn strip_gcode_from_3mf(threemf_data: &[u8]) -> Result<Vec<u8>, String> {
+    let reader = Cursor::new(threemf_data);
+    let mut archive =
+        zip::ZipArchive::new(reader).map_err(|e| format!("bad zip: {e}"))?;
+
+    let mut buf = Vec::new();
+    {
+        let writer = Cursor::new(&mut buf);
+        let mut out = zip::ZipWriter::new(writer);
+        let options = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Deflated);
+
+        for i in 0..archive.len() {
+            let mut entry = archive.by_index(i).map_err(|e| format!("zip entry: {e}"))?;
+            let name = entry.name().to_string();
+
+            let dominated = ALLOWED_CONFIG_FILES.contains(&name.as_str())
+                || (name.starts_with("Metadata/plate_") && name.ends_with(".json"));
+
+            if dominated {
+                let mut data = Vec::new();
+                entry
+                    .read_to_end(&mut data)
+                    .map_err(|e| format!("read {name}: {e}"))?;
+                out.start_file(&name, options)
+                    .map_err(|e| format!("write {name}: {e}"))?;
+                out.write_all(&data)
+                    .map_err(|e| format!("write {name}: {e}"))?;
+            }
+        }
+
+        out.finish().map_err(|e| format!("finalize zip: {e}"))?;
+    }
+    Ok(buf)
+}
+
+// ---------------------------------------------------------------------------
+// Config 3MF color patching (mirrors _patch_config_3mf_colors in bridge.py)
+// ---------------------------------------------------------------------------
+
+/// Patch filament colors in a config-only 3MF to match AMS tray colors.
+/// Mirrors `_patch_config_3mf_colors()` in bridge.py.
+pub fn patch_config_3mf_colors(
+    config_data: &[u8],
+    ams_trays: &[AmsTray],
+    mapping: &[i32],
+) -> Result<Vec<u8>, String> {
+    let tray_by_phys: HashMap<i32, &AmsTray> =
+        ams_trays.iter().map(|t| (t.phys_slot, t)).collect();
+
+    let reader = Cursor::new(config_data);
+    let mut archive =
+        zip::ZipArchive::new(reader).map_err(|e| format!("bad zip: {e}"))?;
+
+    // Read all files into memory
+    let mut file_data: HashMap<String, Vec<u8>> = HashMap::new();
+    for i in 0..archive.len() {
+        let mut entry = archive.by_index(i).map_err(|e| format!("zip entry: {e}"))?;
+        let name = entry.name().to_string();
+        let mut data = Vec::new();
+        entry.read_to_end(&mut data).map_err(|e| format!("read: {e}"))?;
+        file_data.insert(name, data);
+    }
+
+    // Parse and patch slice_info.config (XML)
+    let slice_info_key = "Metadata/slice_info.config";
+    let slice_info = match file_data.get(slice_info_key) {
+        Some(data) => data.clone(),
+        None => return Ok(config_data.to_vec()), // no slice info, nothing to patch
+    };
+
+    let xml_str = String::from_utf8_lossy(&slice_info);
+    let mut changed = false;
+
+    // We need to parse and modify XML. Since roxmltree is read-only, we'll do
+    // string-based patching like the Python code does with ET.
+    // Parse to find filament elements and their colors, then replace in string.
+    let doc = roxmltree::Document::parse(&xml_str)
+        .map_err(|e| format!("parse XML: {e}"))?;
+
+    let plate_el = match doc.descendants().find(|n| n.has_tag_name("plate")) {
+        Some(el) => el,
+        None => return Ok(config_data.to_vec()),
+    };
+
+    // Build replacement map: for each filament, check if color needs updating
+    let mut color_replacements: Vec<(i32, String)> = Vec::new(); // (filament_id, new_color)
+    for f in plate_el.children().filter(|n| n.has_tag_name("filament")) {
+        let fid: i32 = f.attribute("id").and_then(|s| s.parse().ok()).unwrap_or(1);
+        let idx = (fid - 1) as usize;
+        if idx < mapping.len() {
+            let phys_slot = mapping[idx];
+            if let Some(tray) = tray_by_phys.get(&phys_slot) {
+                if phys_slot >= 0 {
+                    let new_color = format!("#{}", tray.color);
+                    let old_color = f.attribute("color").unwrap_or("");
+                    if old_color != new_color {
+                        color_replacements.push((fid, new_color));
+                        changed = true;
+                    }
+                }
+            }
+        }
+    }
+
+    if !changed {
+        return Ok(config_data.to_vec());
+    }
+
+    // Apply replacements to the XML string
+    let mut patched_xml = xml_str.to_string();
+    for (fid, new_color) in &color_replacements {
+        // Find the filament element with this id and replace its color attribute
+        // This is a targeted replacement matching the Python ET behavior
+        let doc = roxmltree::Document::parse(&patched_xml)
+            .map_err(|e| format!("reparse XML: {e}"))?;
+        if let Some(plate) = doc.descendants().find(|n| n.has_tag_name("plate")) {
+            for f in plate.children().filter(|n| n.has_tag_name("filament")) {
+                let this_fid: i32 =
+                    f.attribute("id").and_then(|s| s.parse().ok()).unwrap_or(0);
+                if this_fid == *fid {
+                    if let Some(old_color) = f.attribute("color") {
+                        // Replace color="OLD" with color="NEW" in this specific element
+                        let range = f.range();
+                        let element_str = &patched_xml[range.clone()];
+                        let updated = element_str.replace(
+                            &format!("color=\"{}\"", old_color),
+                            &format!("color=\"{}\"", new_color),
+                        );
+                        patched_xml.replace_range(range, &updated);
+                    }
+                    break;
+                }
+            }
+        }
+    }
+    file_data.insert(slice_info_key.to_string(), patched_xml.into_bytes());
+
+    // Also patch project_settings filament_colour (mirrors Python)
+    if let Some(ps_data) = file_data.get("Metadata/project_settings.config").cloned() {
+        if let Ok(mut ps) = serde_json::from_slice::<serde_json::Value>(&ps_data) {
+            if let Some(colours) = ps.get_mut("filament_colour").and_then(|v| v.as_array_mut()) {
+                for (fid, new_color) in &color_replacements {
+                    let idx = (*fid - 1) as usize;
+                    if idx < colours.len() {
+                        colours[idx] = serde_json::Value::String(new_color.clone());
+                    }
+                }
+                if let Ok(ps_bytes) = serde_json::to_vec(&ps) {
+                    file_data.insert(
+                        "Metadata/project_settings.config".to_string(),
+                        ps_bytes,
+                    );
+                }
+            }
+        }
+    }
+
+    // Rewrite zip
+    let mut buf = Vec::new();
+    {
+        let writer = Cursor::new(&mut buf);
+        let mut out = zip::ZipWriter::new(writer);
+        let options = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Deflated);
+        for (name, data) in &file_data {
+            out.start_file(name, options)
+                .map_err(|e| format!("write {name}: {e}"))?;
+            out.write_all(data)
+                .map_err(|e| format!("write {name}: {e}"))?;
+        }
+        out.finish().map_err(|e| format!("finalize: {e}"))?;
+    }
+    Ok(buf)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_ams_trays_from_real_status() {
+        let status = serde_json::json!({
+            "ams": {
+                "ams": [{
+                    "id": "0",
+                    "tray": [
+                        {"id": "0", "tray_type": "PLA", "tray_color": "FFFFFFFF", "tray_info_idx": "GFL99"},
+                        {"id": "1", "tray_type": "ASA", "tray_color": "BCBCBCFF", "tray_info_idx": "GFB98"},
+                        {"id": "2", "tray_type": "PETG-CF", "tray_color": "2850E0FF", "tray_info_idx": "GFG98"},
+                        {"id": "3", "tray_type": "PLA", "tray_color": "161616FF", "tray_info_idx": "GFL99"},
+                    ]
+                }]
+            }
+        });
+        let trays = parse_ams_trays(&status);
+        assert_eq!(trays.len(), 4);
+        assert_eq!(trays[0].phys_slot, 0);
+        assert_eq!(trays[0].tray_type, "PLA");
+        assert_eq!(trays[0].color, "FFFFFF");
+        assert_eq!(trays[1].phys_slot, 1);
+        assert_eq!(trays[1].tray_type, "ASA");
+        assert_eq!(trays[2].phys_slot, 2);
+        assert_eq!(trays[2].tray_type, "PETG-CF");
+        assert_eq!(trays[3].phys_slot, 3);
+        assert_eq!(trays[3].color, "161616");
+    }
+
+    #[test]
+    fn parse_ams_trays_empty_type_skipped() {
+        let status = serde_json::json!({
+            "ams": {
+                "ams": [{
+                    "id": "0",
+                    "tray": [
+                        {"id": "0", "tray_type": "", "tray_color": "FFFFFF"},
+                        {"id": "1", "tray_type": "PLA", "tray_color": "000000FF"},
+                    ]
+                }]
+            }
+        });
+        let trays = parse_ams_trays(&status);
+        assert_eq!(trays.len(), 1);
+        assert_eq!(trays[0].slot_id, 1);
+    }
+
+    #[test]
+    fn parse_ams_trays_no_ams_data() {
+        let status = serde_json::json!({"gcode_state": "IDLE"});
+        let trays = parse_ams_trays(&status);
+        assert!(trays.is_empty());
+    }
+
+    #[test]
+    fn parse_ams_trays_multi_unit() {
+        let status = serde_json::json!({
+            "ams": {
+                "ams": [
+                    {"id": "0", "tray": [{"id": "0", "tray_type": "PLA", "tray_color": "FFFFFF", "tray_info_idx": ""}]},
+                    {"id": "1", "tray": [{"id": "0", "tray_type": "ABS", "tray_color": "000000", "tray_info_idx": ""}]},
+                ]
+            }
+        });
+        let trays = parse_ams_trays(&status);
+        assert_eq!(trays.len(), 2);
+        assert_eq!(trays[0].phys_slot, 0); // unit 0, slot 0
+        assert_eq!(trays[1].phys_slot, 4); // unit 1, slot 0
+    }
+
+    #[test]
+    fn strip_gcode_from_3mf_basic() {
+        // Create a minimal 3MF zip in memory
+        let mut buf = Vec::new();
+        {
+            let writer = Cursor::new(&mut buf);
+            let mut zip = zip::ZipWriter::new(writer);
+            let opts = zip::write::SimpleFileOptions::default();
+
+            zip.start_file("[Content_Types].xml", opts).unwrap();
+            zip.write_all(b"<Types/>").unwrap();
+
+            zip.start_file("_rels/.rels", opts).unwrap();
+            zip.write_all(b"<Relationships/>").unwrap();
+
+            zip.start_file("Metadata/slice_info.config", opts).unwrap();
+            zip.write_all(b"<config/>").unwrap();
+
+            zip.start_file("Metadata/plate_1.json", opts).unwrap();
+            zip.write_all(b"{}").unwrap();
+
+            // These should be stripped:
+            zip.start_file("Metadata/plate_1.gcode", opts).unwrap();
+            zip.write_all(b"G28\nG1 X10\n").unwrap();
+
+            zip.start_file("Metadata/plate_1.gcode.md5", opts).unwrap();
+            zip.write_all(b"abc123").unwrap();
+
+            zip.start_file("Metadata/plate_1.png", opts).unwrap();
+            zip.write_all(b"PNG_DATA").unwrap();
+
+            zip.finish().unwrap();
+        }
+
+        let config = strip_gcode_from_3mf(&buf).unwrap();
+        let reader = Cursor::new(&config);
+        let archive = zip::ZipArchive::new(reader).unwrap();
+        let names: Vec<&str> = archive.file_names().collect();
+
+        assert!(names.contains(&"[Content_Types].xml"));
+        assert!(names.contains(&"_rels/.rels"));
+        assert!(names.contains(&"Metadata/slice_info.config"));
+        assert!(names.contains(&"Metadata/plate_1.json"));
+        // Stripped:
+        assert!(!names.contains(&"Metadata/plate_1.gcode"));
+        assert!(!names.contains(&"Metadata/plate_1.gcode.md5"));
+        assert!(!names.contains(&"Metadata/plate_1.png"));
+    }
+}

--- a/bridge/src/server.rs
+++ b/bridge/src/server.rs
@@ -60,9 +60,18 @@ impl AppState {
 #[derive(Serialize, Deserialize)]
 pub struct HealthResponse {
     pub status: String,
+    pub pid: u32,
     pub mqtt_connected: bool,
     pub uptime_secs: u64,
     pub cached_devices: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PingResponse {
+    pub status: String,
+    pub pid: u32,
+    pub uptime_secs: u64,
+    pub rss_kb: u64,
 }
 
 #[derive(Serialize)]
@@ -73,6 +82,26 @@ pub struct ErrorResponse {
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
+
+/// GET /ping — lightweight process liveness check.
+/// No mutex, no FFI, no cloud calls. Always fast.
+async fn ping(State(state): State<SharedState>) -> Json<PingResponse> {
+    Json(PingResponse {
+        status: "ok".into(),
+        pid: std::process::id(),
+        uptime_secs: state.started_at.elapsed().as_secs(),
+        rss_kb: read_rss_kb(),
+    })
+}
+
+/// Read resident set size from /proc/self/statm (Linux).
+fn read_rss_kb() -> u64 {
+    std::fs::read_to_string("/proc/self/statm")
+        .ok()
+        .and_then(|s| s.split_whitespace().nth(1)?.parse::<u64>().ok())
+        .map(|pages| pages * 4) // page size = 4KB on Linux
+        .unwrap_or(0)
+}
 
 async fn health(State(state): State<SharedState>) -> Json<HealthResponse> {
     let agent = state.agent.lock().unwrap();
@@ -90,6 +119,7 @@ async fn health(State(state): State<SharedState>) -> Json<HealthResponse> {
 
     Json(HealthResponse {
         status: "ok".into(),
+        pid: std::process::id(),
         mqtt_connected,
         uptime_secs: state.started_at.elapsed().as_secs(),
         cached_devices,
@@ -217,6 +247,225 @@ async fn cancel_print(
     })))
 }
 
+/// POST /print — multipart upload
+///
+/// Fields:
+///   - `file`: the .3mf file (required)
+///   - `params`: JSON string with PrintRequest fields (required)
+///
+/// The handler automatically:
+/// 1. Strips gcode from the 3MF to create a config-only 3MF
+/// 2. Queries AMS tray state from the printer (via cache or live MQTT)
+/// 3. Builds AMS mapping (matching virtual filaments to physical trays)
+/// 4. Patches config 3MF colors to match AMS tray colors
+/// 5. Sends both files + mapping to the Bambu cloud API
+///
+/// This replicates the exact behavior of bridge.py's cloud_print().
+async fn start_print(
+    State(state): State<SharedState>,
+    mut multipart: axum_extra::extract::Multipart,
+) -> Result<Json<crate::agent::PrintResult>, (StatusCode, Json<ErrorResponse>)> {
+    let mut file_bytes: Option<Vec<u8>> = None;
+    let mut params_json: Option<String> = None;
+
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| err(StatusCode::BAD_REQUEST, format!("multipart error: {e}")))?
+    {
+        let name = field.name().unwrap_or("").to_string();
+        match name.as_str() {
+            "file" => {
+                file_bytes = Some(
+                    field
+                        .bytes()
+                        .await
+                        .map_err(|e| err(StatusCode::BAD_REQUEST, format!("read file: {e}")))?
+                        .to_vec(),
+                );
+            }
+            "params" => {
+                params_json = Some(
+                    field
+                        .text()
+                        .await
+                        .map_err(|e| err(StatusCode::BAD_REQUEST, format!("read params: {e}")))?
+                );
+            }
+            _ => {} // ignore unknown fields
+        }
+    }
+
+    let file_data = file_bytes.ok_or_else(|| err(StatusCode::BAD_REQUEST, "missing 'file' field".into()))?;
+    let params_str = params_json.ok_or_else(|| err(StatusCode::BAD_REQUEST, "missing 'params' field".into()))?;
+
+    let mut request: crate::agent::PrintRequest = serde_json::from_str(&params_str)
+        .map_err(|e| err(StatusCode::BAD_REQUEST, format!("invalid params JSON: {e}")))?;
+
+    // Step 1: Strip gcode from 3MF to create config-only 3MF
+    let config_data = crate::print_job::strip_gcode_from_3mf(&file_data)
+        .map_err(|e| err(StatusCode::BAD_REQUEST, format!("strip gcode: {e}")))?;
+
+    // Step 2: Query AMS tray state from printer
+    // Try cache first, fall back to live query
+    let ams_trays = {
+        let printer_status = get_printer_status_for_ams(&state, &request.device_id).await;
+        match printer_status {
+            Some(status) => {
+                let print_data = status.get("print").unwrap_or(&status);
+                crate::print_job::parse_ams_trays(print_data)
+            }
+            None => {
+                tracing::warn!(device_id = %request.device_id, "no cached status for AMS — using empty mapping");
+                Vec::new()
+            }
+        }
+    };
+
+    // Step 3: Build AMS mapping from 3MF filaments vs physical trays
+    let ams_mapping = crate::print_job::build_ams_mapping(&file_data, &ams_trays);
+    tracing::info!(
+        mapping = ?ams_mapping.mapping,
+        trays = ams_trays.len(),
+        "AMS mapping built"
+    );
+
+    // Step 4: Patch config 3MF colors to match AMS tray colors
+    let patched_config = if !ams_trays.is_empty() {
+        crate::print_job::patch_config_3mf_colors(&config_data, &ams_trays, &ams_mapping.mapping)
+            .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, format!("patch colors: {e}")))?
+    } else {
+        config_data
+    };
+
+    // Step 5: Write files to temp directory and set up request
+    let tmp_dir = tempfile::tempdir()
+        .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, format!("tmpdir: {e}")))?;
+
+    // Write main 3MF
+    let basename = std::path::Path::new(&request.filename)
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .into_owned();
+    let file_path = tmp_dir.path().join(&basename);
+    std::fs::write(&file_path, &file_data)
+        .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, format!("write file: {e}")))?;
+    request.filename = file_path.to_string_lossy().into_owned();
+
+    // Write config-only 3MF
+    let stem = std::path::Path::new(&basename)
+        .file_stem()
+        .unwrap_or_default()
+        .to_string_lossy();
+    let cfg_name = format!("{stem}_config.3mf");
+    let cfg_path = tmp_dir.path().join(&cfg_name);
+    std::fs::write(&cfg_path, &patched_config)
+        .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, format!("write config: {e}")))?;
+    request.config_filename = Some(cfg_path.to_string_lossy().into_owned());
+
+    // Set AMS mapping from our computed values
+    let mapping_json = serde_json::to_string(&ams_mapping.mapping).unwrap_or_else(|_| "[]".into());
+    let mapping2_json = serde_json::to_string(&ams_mapping.mapping2).unwrap_or_else(|_| "[]".into());
+    request.ams_mapping = Some(mapping_json);
+    request.ams_mapping2 = Some(mapping2_json);
+
+    tracing::info!(
+        file = %request.filename,
+        config = ?request.config_filename,
+        ams_mapping = ?request.ams_mapping,
+        file_size = file_data.len(),
+        config_size = patched_config.len(),
+        "print request prepared"
+    );
+
+    // Run the blocking FFI call on a separate thread
+    let state_clone = state.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        // Verify files exist before calling FFI
+        let file_exists = std::path::Path::new(&request.filename).exists();
+        let config_exists = request.config_filename.as_ref()
+            .map(|p| std::path::Path::new(p).exists())
+            .unwrap_or(false);
+        tracing::info!(file_exists, config_exists, "pre-print file check");
+
+        let agent = state_clone.agent.lock().unwrap();
+        let res = agent.start_print(&request);
+        // tmp_dir is dropped here, cleaning up files
+        drop(tmp_dir);
+        res
+    })
+    .await
+    .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, format!("task join: {e}")))?
+    .map_err(|e| err(StatusCode::BAD_GATEWAY, e))?;
+
+    let is_error = result.return_code != 0 && result.return_code != -1;
+    if is_error {
+        Err(err(
+            StatusCode::BAD_GATEWAY,
+            format!(
+                "print failed: return_code={}, print_result={}",
+                result.return_code, result.print_result
+            ),
+        ))
+    } else {
+        Ok(Json(result))
+    }
+}
+
+/// Get printer status for AMS tray parsing. Checks cache first, then does a live query.
+async fn get_printer_status_for_ams(
+    state: &SharedState,
+    device_id: &str,
+) -> Option<serde_json::Value> {
+    // Check cache (any age — AMS trays change rarely)
+    {
+        let cache = state.cache.read().unwrap();
+        if let Some(cached) = cache.get(device_id) {
+            return Some(cached.payload.clone());
+        }
+    }
+
+    // No cache — try a live query (blocking, so we spawn)
+    let state_clone = state.clone();
+    let device_id = device_id.to_string();
+    let device_id_for_cache = device_id.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        let agent = state_clone.agent.lock().unwrap();
+        agent.drain_messages();
+        if agent
+            .subscribe_and_pushall(&device_id, Duration::from_secs(10))
+            .is_err()
+        {
+            return None;
+        }
+        let messages = agent.drain_messages();
+        let best = messages.iter().max_by_key(|m| m.payload.len());
+        best.and_then(|msg| serde_json::from_str::<serde_json::Value>(&msg.payload).ok())
+    })
+    .await
+    .ok()
+    .flatten();
+
+    // Cache the result if we got one
+    if let Some(ref payload) = result {
+        let mut cache = state.cache.write().unwrap();
+        cache.insert(
+            device_id_for_cache,
+            DeviceStatus {
+                payload: payload.clone(),
+                updated_at: Instant::now(),
+            },
+        );
+    }
+
+    result
+}
+
+fn err(status: StatusCode, msg: String) -> (StatusCode, Json<ErrorResponse>) {
+    (status, Json(ErrorResponse { error: msg }))
+}
+
 // ---------------------------------------------------------------------------
 // Router
 // ---------------------------------------------------------------------------
@@ -247,12 +496,31 @@ pub fn mock_state(devices: HashMap<String, serde_json::Value>) -> SharedState {
     state
 }
 
+/// POST /shutdown — cleanly stop the daemon.
+/// Uses fast_exit to avoid .so MQTT thread cleanup hangs.
+async fn shutdown() -> Json<serde_json::Value> {
+    tracing::info!("shutdown requested via HTTP");
+    // Spawn a task that exits after a short delay so the response can be sent
+    tokio::spawn(async {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        // flush and fast-exit (same as CLI commands)
+        use std::io::Write;
+        let _ = std::io::stdout().flush();
+        let _ = std::io::stderr().flush();
+        unsafe { libc::_exit(0) }
+    });
+    Json(serde_json::json!({"status": "shutting_down"}))
+}
+
 pub fn router(state: SharedState) -> Router {
     Router::new()
+        .route("/ping", get(ping))
         .route("/health", get(health))
         .route("/status/:device_id", get(get_status))
         .route("/ams/:device_id", get(get_ams))
+        .route("/print", axum::routing::post(start_print))
         .route("/cancel/:device_id", axum::routing::post(cancel_print))
+        .route("/shutdown", axum::routing::post(shutdown))
         .with_state(state)
 }
 


### PR DESCRIPTION
## Summary
- Ports Python `bridge.py` cloud print logic to Rust (`print_job.rs`): config-only 3MF generation, AMS tray parsing, AMS filament mapping, config 3MF color patching
- `POST /print` multipart endpoint orchestrates the full flow: strip gcode → query AMS → build mapping → patch colors → upload to Bambu cloud
- `GET /ping` lightweight liveness check (pid, uptime, RSS) — no mutex, no cloud calls
- `POST /shutdown` clean daemon termination via `_exit(0)`
- FFI bindings for `start_print` with `-3140` enc-flag retry
- **Tested end-to-end on real P1S printer** — successful upload and print start

## Test plan
- [x] 28 unit tests passing (cargo test)
- [x] Real printer test: decoy_base.gcode.3mf uploaded and printing via /print endpoint
- [x] /ping responds instantly even during print (no mutex contention)
- [x] /shutdown cleanly kills daemon
- [ ] Test with multi-filament 3MF to verify AMS mapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)