### PR TITLE
Align ruff config with estampo

### DIFF
--- a/changes/+align-ruff-config.misc
+++ b/changes/+align-ruff-config.misc
@@ -1,0 +1,1 @@
+Align ruff config with estampo (target-version, lint rules, import sorting)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,14 @@ dev = [
 bambox = "bambox.cli:main"
 
 [tool.ruff]
+target-version = "py311"
 line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W"]
+
+[tool.ruff.lint.per-file-ignores]
+"src/bambox/pack.py" = ["E501"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/src/bambox/cli.py
+++ b/src/bambox/cli.py
@@ -121,7 +121,7 @@ def _cmd_print(args: argparse.Namespace) -> None:
 
 def _cmd_status(args: argparse.Namespace) -> None:
     """Query printer status."""
-    from bambox.bridge import load_credentials, query_status, _write_token_json, parse_ams_trays
+    from bambox.bridge import _write_token_json, load_credentials, parse_ams_trays, query_status
 
     creds_path = Path(args.credentials) if args.credentials else None
     credentials = load_credentials(creds_path)

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -15,11 +15,9 @@ import zipfile
 from io import BytesIO
 from pathlib import Path
 
-
 from bambox.assemble import assemble_gcode
 from bambox.pack import FilamentInfo, SliceInfo, pack_gcode_3mf
 from bambox.templates import render_template
-
 
 FIXTURES = Path(__file__).parent / "fixtures"
 PROJECT_SETTINGS = json.loads((FIXTURES / "project_settings.json").read_text())

--- a/tests/test_gcode_compat.py
+++ b/tests/test_gcode_compat.py
@@ -7,7 +7,6 @@ from bambox.gcode_compat import (
     translate_to_bbl,
 )
 
-
 # --- is_bbl_gcode ---
 
 

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -13,7 +13,6 @@ from io import BytesIO
 from pathlib import Path
 from xml.etree import ElementTree as ET
 
-
 from bambox.pack import (
     FilamentInfo,
     SliceInfo,
@@ -21,7 +20,6 @@ from bambox.pack import (
     fixup_project_settings,
     pack_gcode_3mf,
 )
-
 
 FIXTURES = Path(__file__).parent / "fixtures"
 REFERENCE = FIXTURES / "reference.gcode.3mf"

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 from bambox.templates import orca_to_jinja2, render_template
-
 
 # ---------------------------------------------------------------------------
 # OrcaSlicer → Jinja2 conversion


### PR DESCRIPTION
## Summary
- Add `target-version = "py311"` and `select = ["E", "F", "I", "W"]` to ruff config, matching estampo
- Auto-fix import sorting (isort) across src and tests
- Suppress E501 for `pack.py` (long XML template literals that can't be wrapped)

## Test plan
- [x] `ruff check src tests` passes
- [x] `ruff format --check src tests` passes
- [x] `mypy src/bambox` passes
- [x] `pytest` — 87 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)