### PR TITLE
Fix TestPyPI publish: remove PR trigger

### DIFF
--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -3,8 +3,6 @@ name: Publish to TestPyPI
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/changes/+fix-testpypi-trigger.misc
+++ b/changes/+fix-testpypi-trigger.misc
@@ -1,0 +1,1 @@
+Stop running TestPyPI publish on PRs (OIDC ref mismatch)


### PR DESCRIPTION
## Summary
- Remove `pull_request` trigger from test-pypi workflow
- OIDC token on PR runs uses `refs/pull/N/merge` which doesn't match TestPyPI's trusted publisher config, causing every PR to show a failed `test-publish` check

Dev packages are only useful on merge to main, not on every PR.

## Test plan
- [x] PR CI should no longer show a `test-publish` failure
- [ ] Next merge to main should successfully publish to TestPyPI (requires trusted publisher configured on test.pypi.org)

🤖 Generated with [Claude Code](https://claude.com/claude-code)