### PR TITLE
Add bridge cross-compilation workflow and install script

### DIFF
--- a/.github/workflows/build-bridge.yml
+++ b/.github/workflows/build-bridge.yml
@@ -1,0 +1,62 @@
+name: Build bridge binaries
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+jobs:
+  build-bridge:
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: bambu-bridge-linux-x86_64
+          - target: x86_64-apple-darwin
+            os: macos-13
+            artifact: bambu-bridge-macos-x86_64
+          - target: aarch64-apple-darwin
+            os: macos-14
+            artifact: bambu-bridge-macos-arm64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Install g++ (Linux only)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y g++
+      - name: Build
+        working-directory: bridge
+        run: cargo build --release --target ${{ matrix.target }}
+      - name: Package binary
+        run: |
+          mkdir -p dist
+          cp bridge/target/${{ matrix.target }}/release/bambu-bridge dist/${{ matrix.artifact }}
+          chmod +x dist/${{ matrix.artifact }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: dist/${{ matrix.artifact }}
+
+  release-assets:
+    needs: build-bridge
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Upload to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          for f in dist/*; do
+            gh release upload "$TAG" "$f" --repo "${{ github.repository }}" --clobber
+          done

--- a/changes/+bridge-cross-compile.misc
+++ b/changes/+bridge-cross-compile.misc
@@ -1,0 +1,1 @@
+Add CI workflow for cross-compiling bridge binaries (Linux, macOS) and install script

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# Install bambu-bridge — standalone Bambu Lab printer bridge
+set -e
+
+REPO="estampo/bambox"
+INSTALL_DIR="${BAMBOX_INSTALL_DIR:-$HOME/.local/bin}"
+
+# Detect platform
+OS=$(uname -s)
+ARCH=$(uname -m)
+
+case "$OS" in
+  Linux)  PLATFORM="linux" ;;
+  Darwin) PLATFORM="macos" ;;
+  *)      echo "Unsupported OS: $OS"; exit 1 ;;
+esac
+
+case "$ARCH" in
+  x86_64|amd64) ARCH_TAG="x86_64" ;;
+  arm64|aarch64) ARCH_TAG="arm64" ;;
+  *)             echo "Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+BINARY="bambu-bridge-${PLATFORM}-${ARCH_TAG}"
+
+# Get latest release tag
+TAG=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | head -1 | cut -d'"' -f4)
+if [ -z "$TAG" ]; then
+  echo "Error: could not determine latest release"
+  exit 1
+fi
+
+URL="https://github.com/${REPO}/releases/download/${TAG}/${BINARY}"
+
+echo "Downloading bambu-bridge ${TAG} for ${PLATFORM}/${ARCH_TAG}..."
+mkdir -p "$INSTALL_DIR"
+curl -fsSL -o "${INSTALL_DIR}/bambu-bridge" "$URL"
+chmod +x "${INSTALL_DIR}/bambu-bridge"
+
+echo ""
+echo "Installed bambu-bridge to ${INSTALL_DIR}/bambu-bridge"
+echo ""
+if ! echo "$PATH" | tr ':' '\n' | grep -q "^${INSTALL_DIR}$"; then
+  echo "Add ${INSTALL_DIR} to your PATH:"
+  echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+  echo ""
+fi
+echo "Run 'bambu-bridge --help' to get started."
+echo "The Bambu networking library will be downloaded automatically on first use."


### PR DESCRIPTION
## Summary
- Add `.github/workflows/build-bridge.yml` -- CI workflow that cross-compiles `bambu-bridge` for Linux x86_64, macOS x86_64, and macOS arm64 using matrix builds
- On tagged releases (`v*`), upload binaries as GitHub Release assets
- Add `install.sh` -- POSIX shell script that auto-detects platform/arch and downloads the latest bridge binary from GitHub Releases

Part of #37

## Test plan
- [ ] Trigger workflow manually via `workflow_dispatch` and verify all three matrix builds succeed
- [ ] Verify artifacts are uploaded (check Actions run artifacts)
- [ ] Test `install.sh` on Linux and macOS (both x86_64 and arm64 if available)
- [ ] Create a test tag and verify binaries appear on the GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)