### PR TITLE
Bridge auto-fetches networking library on first run

### DIFF
--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -64,7 +64,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -75,7 +75,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -243,7 +243,9 @@ dependencies = [
  "axum-test",
  "cc",
  "clap",
+ "dirs",
  "libc",
+ "reqwest",
  "roxmltree",
  "serde",
  "serde_json",
@@ -255,6 +257,12 @@ dependencies = [
  "tracing-subscriber",
  "zip",
 ]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -331,6 +339,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cipher"
@@ -497,6 +511,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,7 +564,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -633,8 +668,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -772,18 +809,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http 1.4.0",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.4.0",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -922,6 +979,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,6 +1022,8 @@ version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -970,6 +1045,15 @@ name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libredox"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -997,6 +1081,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lzma-rs"
@@ -1074,7 +1164,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1100,7 +1190,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1120,6 +1210,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -1226,6 +1322,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,8 +1404,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1264,7 +1425,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1277,12 +1448,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1303,12 +1494,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "reserve-port"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94070964579245eb2f76e62a7668fe87bd9969ed6c41256f3bf614e3323dd3cc"
 dependencies = [
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1329,9 +1572,15 @@ dependencies = [
  "http 0.2.12",
  "mime",
  "mime_guess",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -1343,7 +1592,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1506,7 +1790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1549,6 +1833,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -1571,7 +1858,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1665,6 +1952,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1678,7 +1980,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1690,6 +1992,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -1757,9 +2069,12 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags",
  "bytes",
+ "futures-util",
  "http 1.4.0",
  "http-body",
+ "iri-string",
  "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1870,6 +2185,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1952,6 +2273,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2018,10 +2349,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2031,6 +2409,135 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -20,6 +20,8 @@ tower-http = { version = "0.6", features = ["cors", "trace"] }
 axum-extra = { version = "0.9", features = ["multipart"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+dirs = "6"
 
 [build-dependencies]
 cc = "1"

--- a/bridge/build.rs
+++ b/bridge/build.rs
@@ -5,8 +5,11 @@ fn main() {
         .file("shim/shim.cpp")
         .compile("bambu_shim");
 
-    // Link dl for dlopen/dlsym and pthread for threading
-    println!("cargo:rustc-link-lib=dl");
+    // Link dl for dlopen/dlsym — only needed on Linux (macOS has it in libSystem)
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    if target_os == "linux" {
+        println!("cargo:rustc-link-lib=dl");
+    }
     println!("cargo:rustc-link-lib=pthread");
     println!("cargo:rustc-link-lib=stdc++");
     println!("cargo:rerun-if-changed=shim/shim.cpp");

--- a/bridge/src/agent.rs
+++ b/bridge/src/agent.rs
@@ -164,12 +164,28 @@ pub struct BambuAgent {
     agent: *mut c_void,
     // Box to ensure stable address for callback context pointer
     state: Box<CallbackState>,
+    /// Base directory for cert/config/log files.
+    data_dir: String,
 }
 
 // The agent pointer is thread-safe (the .so manages its own locking)
 unsafe impl Send for BambuAgent {}
 
 impl BambuAgent {
+    /// Determine the base directory for agent data (cert, config, log).
+    ///
+    /// Prefers the platform cache dir if it contains the cert file,
+    /// otherwise falls back to `/tmp/bambu_agent/` (Docker compatibility).
+    fn resolve_data_dir() -> String {
+        if let Some(cache) = crate::fetch::cache_dir() {
+            let cert = cache.join("cert").join("slicer_base64.cer");
+            if cert.is_file() {
+                return cache.to_string_lossy().into_owned();
+            }
+        }
+        "/tmp/bambu_agent".to_string()
+    }
+
     /// Load the .so library and create an agent.
     pub fn new(lib_path: &str) -> Result<Self, String> {
         let c_path = CString::new(lib_path).map_err(|e| e.to_string())?;
@@ -196,27 +212,33 @@ impl BambuAgent {
             std::env::set_var("SSL_CERT_FILE", "/etc/ssl/certs/ca-certificates.crt");
         }
 
-        // Create directories the .so expects
-        let _ = std::fs::create_dir_all("/tmp/bambu_agent/log");
-        let _ = std::fs::create_dir_all("/tmp/bambu_agent/config");
-        let _ = std::fs::create_dir_all("/tmp/bambu_agent/cert");
+        let data_dir = Self::resolve_data_dir();
 
-        let log_dir = CString::new("/tmp/bambu_agent/log").unwrap();
+        // Create directories the .so expects
+        let _ = std::fs::create_dir_all(format!("{data_dir}/log"));
+        let _ = std::fs::create_dir_all(format!("{data_dir}/config"));
+        let _ = std::fs::create_dir_all(format!("{data_dir}/cert"));
+
+        let log_dir = CString::new(format!("{data_dir}/log")).unwrap();
         let agent = unsafe { ffi::bambu_shim_create_agent(log_dir.as_ptr()) };
         if agent.is_null() {
             return Err("create_agent returned null".into());
         }
 
         let state = Box::new(CallbackState::new());
-        let mut this = Self { agent, state };
+        let mut this = Self {
+            agent,
+            state,
+            data_dir,
+        };
         this.configure()?;
         Ok(this)
     }
 
     /// Set up directories, certs, headers, and register all callbacks.
     fn configure(&mut self) -> Result<(), String> {
-        let config_dir = CString::new("/tmp/bambu_agent/config").unwrap();
-        let cert_dir = CString::new("/tmp/bambu_agent/cert").unwrap();
+        let config_dir = CString::new(format!("{}/config", self.data_dir)).unwrap();
+        let cert_dir = CString::new(format!("{}/cert", self.data_dir)).unwrap();
         let cert_name = CString::new("slicer_base64.cer").unwrap();
         let country = CString::new("US").unwrap();
 
@@ -563,6 +585,7 @@ impl BambuAgent {
         Self {
             agent: std::ptr::null_mut(),
             state: Box::new(CallbackState::new()),
+            data_dir: "/tmp/bambu_agent".to_string(),
         }
     }
 

--- a/bridge/src/fetch.rs
+++ b/bridge/src/fetch.rs
@@ -1,0 +1,259 @@
+//! Auto-fetch Bambu Lab's `libbambu_networking` shared library.
+//!
+//! On first run (when the .so is not found at the configured path), this module
+//! downloads it from Bambu's CDN and caches it in a platform-aware directory.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+/// Library filename for the current platform.
+#[cfg(target_os = "linux")]
+const LIB_FILENAME: &str = "libbambu_networking.so";
+#[cfg(target_os = "macos")]
+const LIB_FILENAME: &str = "libbambu_networking.dylib";
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+const LIB_FILENAME: &str = "libbambu_networking.so";
+
+/// Default Docker path (unchanged for backwards compatibility).
+const DOCKER_LIB_PATH: &str = "/tmp/bambu_plugin/libbambu_networking.so";
+
+/// TLS cert URL from BambuStudio repository.
+const CERT_URL: &str =
+    "https://raw.githubusercontent.com/bambulab/BambuStudio/master/resources/cert/slicer_base64.cer";
+
+/// Return the platform-specific cache directory for bambox.
+pub fn cache_dir() -> Option<PathBuf> {
+    dirs::data_dir().map(|d| d.join("bambox"))
+}
+
+/// Ensure the networking library is available, downloading if needed.
+///
+/// Returns the resolved path to the library file.
+pub async fn ensure_library(
+    lib_path: &str,
+    no_fetch: bool,
+    plugin_version: &str,
+) -> Result<String, String> {
+    // 1. If the explicit path exists, use it directly.
+    if Path::new(lib_path).is_file() {
+        tracing::debug!(path = lib_path, "library found at configured path");
+        return Ok(lib_path.to_string());
+    }
+
+    // 2. Check platform cache directory.
+    if let Some(cache) = cache_dir() {
+        let cached_lib = cache.join(LIB_FILENAME);
+        if cached_lib.is_file() {
+            tracing::info!(path = %cached_lib.display(), "using cached library");
+            ensure_cert(&cache).await;
+            ensure_subdirs(&cache);
+            return Ok(cached_lib.to_string_lossy().into_owned());
+        }
+    }
+
+    // 3. Nothing found — download or fail.
+    if no_fetch {
+        return Err(format!(
+            "library not found at '{}' and auto-fetch is disabled (--no-fetch)",
+            lib_path
+        ));
+    }
+
+    let cache = cache_dir().ok_or("cannot determine cache directory")?;
+    std::fs::create_dir_all(&cache)
+        .map_err(|e| format!("cannot create cache dir {}: {e}", cache.display()))?;
+
+    tracing::info!(
+        version = plugin_version,
+        cache = %cache.display(),
+        "downloading Bambu networking library"
+    );
+
+    let lib_dest = download_library(&cache, plugin_version).await?;
+    ensure_cert(&cache).await;
+    ensure_subdirs(&cache);
+
+    Ok(lib_dest)
+}
+
+/// Create subdirectories the agent expects (log, config, cert).
+fn ensure_subdirs(base: &Path) {
+    for sub in &["log", "config", "cert"] {
+        let _ = std::fs::create_dir_all(base.join(sub));
+    }
+}
+
+/// Download the TLS cert if not already cached.
+async fn ensure_cert(cache: &Path) {
+    let cert_dir = cache.join("cert");
+    let _ = std::fs::create_dir_all(&cert_dir);
+    let cert_path = cert_dir.join("slicer_base64.cer");
+    if cert_path.is_file() {
+        return;
+    }
+
+    tracing::info!("downloading TLS certificate");
+    match download_file(CERT_URL).await {
+        Ok(bytes) => {
+            if let Err(e) = std::fs::write(&cert_path, &bytes) {
+                tracing::warn!(error = %e, "failed to write cert file");
+            }
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to download TLS cert (non-fatal)");
+        }
+    }
+}
+
+/// Download the library from Bambu's CDN and extract the .so/.dylib.
+async fn download_library(cache: &Path, plugin_version: &str) -> Result<String, String> {
+    // Step 1: Query the slicer resource API for the CDN URL.
+    let api_url = format!(
+        "https://api.bambulab.com/v1/iot-service/api/slicer/resource?slicer/plugins/cloud={}",
+        plugin_version
+    );
+
+    let client = reqwest::Client::builder()
+        .user_agent("bambu-bridge/0.1")
+        .build()
+        .map_err(|e| format!("HTTP client error: {e}"))?;
+
+    tracing::debug!(url = %api_url, "querying plugin resource API");
+    let resp = client
+        .get(&api_url)
+        .send()
+        .await
+        .map_err(|e| format!("API request failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(format!("API returned status {}", resp.status()));
+    }
+
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("invalid API response: {e}"))?;
+
+    // Find the resource entry whose "type" contains "plugins".
+    let cdn_url = find_plugin_url(&body)?;
+    tracing::debug!(url = %cdn_url, "downloading plugin ZIP");
+
+    // Step 2: Download the ZIP.
+    let zip_bytes = download_file(&cdn_url).await?;
+    tracing::info!(bytes = zip_bytes.len(), "downloaded plugin ZIP");
+
+    // Step 3: Extract the library from the ZIP.
+    let lib_dest = cache.join(LIB_FILENAME);
+    extract_library(&zip_bytes, &lib_dest)?;
+
+    tracing::info!(path = %lib_dest.display(), "library extracted");
+    Ok(lib_dest.to_string_lossy().into_owned())
+}
+
+/// Parse the API response JSON and find the CDN download URL.
+fn find_plugin_url(json: &serde_json::Value) -> Result<String, String> {
+    // The response can be either:
+    //   { "resources": [ { "type": "..plugins..", "url": "..." }, ... ] }
+    // or:
+    //   { "software": { ... }, "plugins": { "url": "..." } }
+
+    // Try array format first.
+    if let Some(resources) = json.get("resources").and_then(|r| r.as_array()) {
+        for entry in resources {
+            let entry_type = entry.get("type").and_then(|t| t.as_str()).unwrap_or("");
+            if entry_type.contains("plugins") {
+                if let Some(url) = entry.get("url").and_then(|u| u.as_str()) {
+                    return Ok(url.to_string());
+                }
+            }
+        }
+    }
+
+    // Try the plugins key directly.
+    if let Some(plugins) = json.get("plugins") {
+        if let Some(url) = plugins.get("url").and_then(|u| u.as_str()) {
+            return Ok(url.to_string());
+        }
+    }
+
+    Err(format!(
+        "no plugin download URL found in API response: {}",
+        serde_json::to_string_pretty(json).unwrap_or_default()
+    ))
+}
+
+/// Download a URL and return the bytes.
+async fn download_file(url: &str) -> Result<Vec<u8>, String> {
+    let client = reqwest::Client::builder()
+        .user_agent("bambu-bridge/0.1")
+        .build()
+        .map_err(|e| format!("HTTP client error: {e}"))?;
+
+    let resp = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| format!("download failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(format!("download returned status {}", resp.status()));
+    }
+
+    resp.bytes()
+        .await
+        .map(|b| b.to_vec())
+        .map_err(|e| format!("failed to read response body: {e}"))
+}
+
+/// Extract the library file from a ZIP archive.
+fn extract_library(zip_bytes: &[u8], dest: &Path) -> Result<(), String> {
+    let cursor = std::io::Cursor::new(zip_bytes);
+    let mut archive =
+        zip::ZipArchive::new(cursor).map_err(|e| format!("invalid ZIP archive: {e}"))?;
+
+    for i in 0..archive.len() {
+        let mut file = archive
+            .by_index(i)
+            .map_err(|e| format!("ZIP entry error: {e}"))?;
+        let name = file.name().to_string();
+
+        // Look for the library file anywhere in the archive.
+        if name.ends_with(LIB_FILENAME) {
+            let mut buf = Vec::new();
+            file.read_to_end(&mut buf)
+                .map_err(|e| format!("failed to read {name} from ZIP: {e}"))?;
+            std::fs::write(dest, &buf)
+                .map_err(|e| format!("failed to write {}: {e}", dest.display()))?;
+
+            // Make executable on Unix.
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = std::fs::set_permissions(dest, std::fs::Permissions::from_mode(0o755));
+            }
+
+            return Ok(());
+        }
+    }
+
+    // List what we found for debugging.
+    let names: Vec<String> = (0..archive.len())
+        .filter_map(|i| archive.by_index(i).ok().map(|f| f.name().to_string()))
+        .collect();
+    Err(format!(
+        "{} not found in ZIP archive. Contents: {:?}",
+        LIB_FILENAME, names
+    ))
+}
+
+/// Resolve the default library path: prefer cache dir, fall back to Docker path.
+pub fn default_lib_path() -> String {
+    if let Some(cache) = cache_dir() {
+        let cached = cache.join(LIB_FILENAME);
+        if cached.is_file() {
+            return cached.to_string_lossy().into_owned();
+        }
+    }
+    // Fall back to Docker path (works inside the container).
+    DOCKER_LIB_PATH.to_string()
+}

--- a/bridge/src/main.rs
+++ b/bridge/src/main.rs
@@ -5,6 +5,7 @@
 
 mod agent;
 mod callbacks;
+mod fetch;
 mod ffi;
 mod print_job;
 mod server;
@@ -29,9 +30,17 @@ struct Cli {
     #[arg(
         long,
         env = "BAMBU_LIB_PATH",
-        default_value = "/tmp/bambu_plugin/libbambu_networking.so"
+        default_value_t = fetch::default_lib_path(),
     )]
     lib_path: String,
+
+    /// Disable auto-download of the networking library
+    #[arg(long, global = true)]
+    no_fetch: bool,
+
+    /// Bambu plugin version for auto-download
+    #[arg(long, default_value = "02.05.00.00", global = true)]
+    plugin_version: String,
 
     /// Verbose debug output
     #[arg(short, long, global = true)]
@@ -263,6 +272,16 @@ async fn main() {
         .with_writer(io::stderr)
         .init();
 
+    // Resolve library path (auto-download if needed).
+    let lib_path =
+        match fetch::ensure_library(&cli.lib_path, cli.no_fetch, &cli.plugin_version).await {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("error: {e}");
+                process::exit(1);
+            }
+        };
+
     match &cli.command {
         Command::Status {
             device_id,
@@ -270,7 +289,7 @@ async fn main() {
         } => {
             suppress_stdout();
             let creds = load_credentials(credentials);
-            let agent = init_agent(&cli.lib_path, &creds);
+            let agent = init_agent(&lib_path, &creds);
             cmd_status(&agent, device_id);
             fast_exit(0);
         }
@@ -280,7 +299,7 @@ async fn main() {
         } => {
             suppress_stdout();
             let creds = load_credentials(credentials);
-            let agent = init_agent(&cli.lib_path, &creds);
+            let agent = init_agent(&lib_path, &creds);
             cmd_watch(&agent, device_id);
             fast_exit(0);
         }
@@ -291,7 +310,7 @@ async fn main() {
         } => {
             suppress_stdout();
             let creds = load_credentials(credentials);
-            let agent = init_agent(&cli.lib_path, &creds);
+            let agent = init_agent(&lib_path, &creds);
             restore_stdout();
 
             let state = server::AppState::new(agent);

--- a/changes/37.feature
+++ b/changes/37.feature
@@ -1,0 +1,1 @@
+Bridge binary auto-fetches Bambu networking library on first run; standalone use without Docker


### PR DESCRIPTION
## Summary
- Add `bridge/src/fetch.rs` module that auto-downloads `libbambu_networking.so` from Bambu's CDN on first run, with platform-aware caching (`~/.local/share/bambox/` on Linux, `~/Library/Application Support/bambox/` on macOS)
- Add `--no-fetch` flag to disable auto-download and `--plugin-version` to specify the Bambu plugin version
- Update `BambuAgent` to resolve cert/config/log paths from the cache dir (falling back to `/tmp/bambu_agent/` for Docker compatibility)
- Make `build.rs` conditionally link `-ldl` only on Linux (macOS includes dlopen in libSystem)

Part of #37

## Test plan
- [ ] Verify `cargo check` passes (confirmed locally)
- [ ] Test with existing Docker workflow (lib at `/tmp/bambu_plugin/`) — should work unchanged
- [ ] Test standalone: remove any cached lib, run without `--no-fetch`, confirm it downloads and caches
- [ ] Test `--no-fetch` flag fails gracefully when lib is missing
- [ ] Test `--lib-path` override still works
- [ ] CI cross-compilation (follow-up PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)