### PR TITLE
Bridge CLI: credentials, printer discovery, platform fetch

### DIFF
--- a/bridge/src/fetch.rs
+++ b/bridge/src/fetch.rs
@@ -105,6 +105,18 @@ async fn ensure_cert(cache: &Path) {
     }
 }
 
+/// OS type string for the Bambu API `X-BBL-OS-Type` header.
+fn bbl_os_type() -> &'static str {
+    #[cfg(target_os = "linux")]
+    { "linux" }
+    #[cfg(target_os = "macos")]
+    { "macos" }
+    #[cfg(target_os = "windows")]
+    { "windows" }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    { "linux" }
+}
+
 /// Download the library from Bambu's CDN and extract the .so/.dylib.
 async fn download_library(cache: &Path, plugin_version: &str) -> Result<String, String> {
     // Step 1: Query the slicer resource API for the CDN URL.
@@ -114,13 +126,14 @@ async fn download_library(cache: &Path, plugin_version: &str) -> Result<String, 
     );
 
     let client = reqwest::Client::builder()
-        .user_agent("bambu-bridge/0.1")
+        .user_agent(format!("BambuStudio/{}", plugin_version))
         .build()
         .map_err(|e| format!("HTTP client error: {e}"))?;
 
-    tracing::debug!(url = %api_url, "querying plugin resource API");
+    tracing::debug!(url = %api_url, os_type = bbl_os_type(), "querying plugin resource API");
     let resp = client
         .get(&api_url)
+        .header("X-BBL-OS-Type", bbl_os_type())
         .send()
         .await
         .map_err(|e| format!("API request failed: {e}"))?;

--- a/bridge/src/main.rs
+++ b/bridge/src/main.rs
@@ -20,6 +20,14 @@ use clap::{Parser, Subcommand};
 
 use agent::{BambuAgent, Credentials};
 
+/// Default credentials path: `~/.config/estampo/credentials.toml`
+fn default_credentials_path() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("estampo")
+        .join("credentials.toml")
+}
+
 #[derive(Parser)]
 #[command(name = "bambu-bridge", about = "Bambu Lab printer bridge")]
 struct Cli {
@@ -33,6 +41,10 @@ struct Cli {
         default_value_t = fetch::default_lib_path(),
     )]
     lib_path: String,
+
+    /// Path to credentials file (TOML or JSON)
+    #[arg(long, short, global = true, env = "BAMBU_CREDENTIALS")]
+    credentials: Option<PathBuf>,
 
     /// Disable auto-download of the networking library
     #[arg(long, global = true)]
@@ -51,22 +63,16 @@ struct Cli {
 enum Command {
     /// Query live printer state via MQTT (JSON output)
     Status {
-        /// Bambu device ID
-        device_id: String,
-        /// Path to token JSON file or credentials TOML
-        credentials: PathBuf,
+        /// Bambu device ID (omit to show all printers)
+        device_id: Option<String>,
     },
     /// Long-lived mode: login once, accept commands on stdin
     Watch {
         /// Bambu device ID
         device_id: String,
-        /// Path to token JSON file or credentials TOML
-        credentials: PathBuf,
     },
     /// Start HTTP API daemon on localhost
     Daemon {
-        /// Path to token JSON file or credentials TOML
-        credentials: PathBuf,
         /// Port to listen on
         #[arg(short, long, default_value = "8765")]
         port: u16,
@@ -109,6 +115,22 @@ fn fast_exit(code: i32) -> ! {
     unsafe { libc::_exit(code) }
 }
 
+/// Resolve the credentials path: explicit flag > env var > default location.
+fn resolve_credentials_path(explicit: &Option<PathBuf>) -> PathBuf {
+    if let Some(p) = explicit {
+        return p.clone();
+    }
+    let default = default_credentials_path();
+    if default.is_file() {
+        return default;
+    }
+    eprintln!(
+        "error: no credentials file found. Pass --credentials or create {}",
+        default_credentials_path().display()
+    );
+    process::exit(1);
+}
+
 fn load_credentials(path: &PathBuf) -> Credentials {
     if let Some(ext) = path.extension() {
         if ext == "toml" {
@@ -137,6 +159,30 @@ fn load_credentials(path: &PathBuf) -> Credentials {
     }
 }
 
+/// Load printer entries from a TOML credentials file.
+/// Returns a list of (name, serial) pairs from `[printers.*]` sections.
+fn load_printers_from_toml(path: &PathBuf) -> Vec<(String, String)> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(t) => t,
+        Err(_) => return Vec::new(),
+    };
+    let doc: toml::Value = match text.parse() {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    let printers = match doc.get("printers").and_then(|p| p.as_table()) {
+        Some(t) => t,
+        None => return Vec::new(),
+    };
+    printers
+        .iter()
+        .filter_map(|(name, val)| {
+            let serial = val.get("serial")?.as_str()?;
+            Some((name.clone(), serial.to_string()))
+        })
+        .collect()
+}
+
 fn init_agent(lib_path: &str, creds: &Credentials) -> BambuAgent {
     let agent = match BambuAgent::new(lib_path) {
         Ok(a) => a,
@@ -155,26 +201,6 @@ fn init_agent(lib_path: &str, creds: &Credentials) -> BambuAgent {
 /// Find the best (largest, most complete) message from a set.
 fn best_message(messages: &[callbacks::MqttMessage]) -> Option<&callbacks::MqttMessage> {
     messages.iter().max_by_key(|m| m.payload.len())
-}
-
-fn cmd_status(agent: &BambuAgent, device_id: &str) {
-    if let Err(e) = agent.subscribe_and_pushall(device_id, Duration::from_secs(10)) {
-        eprintln!("error: {e}");
-        process::exit(1);
-    }
-
-    let messages = agent.drain_messages();
-    restore_stdout();
-
-    match best_message(&messages) {
-        Some(msg) => {
-            println!("{}", msg.payload);
-        }
-        None => {
-            eprintln!("error: no status received from printer {device_id}");
-            fast_exit(2);
-        }
-    }
 }
 
 fn cmd_watch(agent: &BambuAgent, device_id: &str) {
@@ -282,38 +308,79 @@ async fn main() {
             }
         };
 
+    let creds_path = resolve_credentials_path(&cli.credentials);
+
     match &cli.command {
-        Command::Status {
-            device_id,
-            credentials,
-        } => {
+        Command::Status { device_id } => {
+            // If no device_id, list all printers from credentials
+            let device_ids: Vec<(String, String)> = match device_id {
+                Some(id) => vec![("".to_string(), id.clone())],
+                None => {
+                    let printers = load_printers_from_toml(&creds_path);
+                    if printers.is_empty() {
+                        eprintln!("error: no device_id provided and no [printers.*] sections in credentials");
+                        process::exit(1);
+                    }
+                    printers
+                }
+            };
+
             suppress_stdout();
-            let creds = load_credentials(credentials);
+            let creds = load_credentials(&creds_path);
             let agent = init_agent(&lib_path, &creds);
-            cmd_status(&agent, device_id);
+
+            let mut results = Vec::new();
+            for (name, dev_id) in &device_ids {
+                if let Err(e) =
+                    agent.subscribe_and_pushall(dev_id, Duration::from_secs(10))
+                {
+                    restore_stdout();
+                    eprintln!("error: {e}");
+                    fast_exit(1);
+                }
+                let messages = agent.drain_messages();
+                if let Some(msg) = best_message(&messages) {
+                    let mut val: serde_json::Value =
+                        serde_json::from_str(&msg.payload).unwrap_or_else(|_| {
+                            serde_json::json!({"raw": msg.payload})
+                        });
+                    if !name.is_empty() {
+                        val["_printer_name"] = serde_json::json!(name);
+                    }
+                    val["_device_id"] = serde_json::json!(dev_id);
+                    results.push(val);
+                } else {
+                    results.push(serde_json::json!({
+                        "_device_id": dev_id,
+                        "_printer_name": name,
+                        "error": "no status received"
+                    }));
+                }
+            }
+
+            restore_stdout();
+            if results.len() == 1 {
+                println!("{}", serde_json::to_string(&results[0]).unwrap());
+            } else {
+                println!("{}", serde_json::to_string(&results).unwrap());
+            }
             fast_exit(0);
         }
-        Command::Watch {
-            device_id,
-            credentials,
-        } => {
+        Command::Watch { device_id } => {
             suppress_stdout();
-            let creds = load_credentials(credentials);
+            let creds = load_credentials(&creds_path);
             let agent = init_agent(&lib_path, &creds);
             cmd_watch(&agent, device_id);
             fast_exit(0);
         }
-        Command::Daemon {
-            credentials,
-            port,
-            bind,
-        } => {
+        Command::Daemon { port, bind } => {
+            let printers = load_printers_from_toml(&creds_path);
             suppress_stdout();
-            let creds = load_credentials(credentials);
+            let creds = load_credentials(&creds_path);
             let agent = init_agent(&lib_path, &creds);
             restore_stdout();
 
-            let state = server::AppState::new(agent);
+            let state = server::AppState::new(agent, printers);
             let app = server::router(state);
 
             let addr: SocketAddr = format!("{bind}:{port}")

--- a/bridge/src/server.rs
+++ b/bridge/src/server.rs
@@ -2,6 +2,7 @@
 //!
 //! Endpoints:
 //!   GET  /health            — daemon health + MQTT connection state
+//!   GET  /printers          — list configured printers with cached status summary
 //!   GET  /status/:device_id — cached printer status (instant) or live query
 //!   GET  /ams/:device_id    — AMS tray info extracted from cached status
 //!   POST /cancel/:device_id — cancel current print
@@ -31,12 +32,21 @@ pub struct DeviceStatus {
     pub updated_at: Instant,
 }
 
+/// Configured printer entry from credentials file.
+#[derive(Clone, Debug, Serialize)]
+pub struct PrinterEntry {
+    pub name: String,
+    pub serial: String,
+}
+
 /// Shared state across all HTTP handlers.
 pub struct AppState {
     /// The FFI agent (behind Mutex because it's not Sync).
     pub agent: Mutex<BambuAgent>,
     /// Cached printer status per device_id.
     pub cache: RwLock<HashMap<String, DeviceStatus>>,
+    /// Configured printers from credentials file.
+    pub printers: Vec<PrinterEntry>,
     /// When the daemon started.
     pub started_at: Instant,
 }
@@ -44,10 +54,14 @@ pub struct AppState {
 pub type SharedState = Arc<AppState>;
 
 impl AppState {
-    pub fn new(agent: BambuAgent) -> SharedState {
+    pub fn new(agent: BambuAgent, printers: Vec<(String, String)>) -> SharedState {
         Arc::new(Self {
             agent: Mutex::new(agent),
             cache: RwLock::new(HashMap::new()),
+            printers: printers
+                .into_iter()
+                .map(|(name, serial)| PrinterEntry { name, serial })
+                .collect(),
             started_at: Instant::now(),
         })
     }
@@ -221,6 +235,50 @@ async fn get_ams(
             }),
         )),
     }
+}
+
+/// GET /printers — list configured printers with cached status summary.
+async fn list_printers(State(state): State<SharedState>) -> Json<serde_json::Value> {
+    let cache = state.cache.read().unwrap();
+    let printers: Vec<serde_json::Value> = state
+        .printers
+        .iter()
+        .map(|p| {
+            let mut entry = serde_json::json!({
+                "name": p.name,
+                "serial": p.serial,
+            });
+            if let Some(status) = cache.get(&p.serial) {
+                let print_data = status.payload.get("print").unwrap_or(&status.payload);
+                entry["gcode_state"] = print_data
+                    .get("gcode_state")
+                    .cloned()
+                    .unwrap_or(serde_json::json!(null));
+                entry["nozzle_temper"] = print_data
+                    .get("nozzle_temper")
+                    .cloned()
+                    .unwrap_or(serde_json::json!(null));
+                entry["bed_temper"] = print_data
+                    .get("bed_temper")
+                    .cloned()
+                    .unwrap_or(serde_json::json!(null));
+                entry["subtask_name"] = print_data
+                    .get("subtask_name")
+                    .cloned()
+                    .unwrap_or(serde_json::json!(null));
+                entry["mc_percent"] = print_data
+                    .get("mc_percent")
+                    .cloned()
+                    .unwrap_or(serde_json::json!(null));
+                entry["cached"] = serde_json::json!(true);
+                entry["cache_age_secs"] = serde_json::json!(status.updated_at.elapsed().as_secs());
+            } else {
+                entry["cached"] = serde_json::json!(false);
+            }
+            entry
+        })
+        .collect();
+    Json(serde_json::json!({ "printers": printers }))
 }
 
 async fn cancel_print(
@@ -473,8 +531,14 @@ fn err(status: StatusCode, msg: String) -> (StatusCode, Json<ErrorResponse>) {
 /// Build an AppState with pre-populated cache (for testing without FFI).
 #[cfg(test)]
 pub fn mock_state(devices: HashMap<String, serde_json::Value>) -> SharedState {
-    // We can't create a real BambuAgent without the .so, so we use a test-only
-    // constructor. The agent field won't be accessed in tests that only hit cache.
+    mock_state_with_printers(devices, Vec::new())
+}
+
+#[cfg(test)]
+pub fn mock_state_with_printers(
+    devices: HashMap<String, serde_json::Value>,
+    printers: Vec<(String, String)>,
+) -> SharedState {
     let state = Arc::new(AppState {
         agent: Mutex::new(unsafe { BambuAgent::test_null() }),
         cache: RwLock::new(
@@ -491,6 +555,10 @@ pub fn mock_state(devices: HashMap<String, serde_json::Value>) -> SharedState {
                 })
                 .collect(),
         ),
+        printers: printers
+            .into_iter()
+            .map(|(name, serial)| PrinterEntry { name, serial })
+            .collect(),
         started_at: Instant::now(),
     });
     state
@@ -516,6 +584,7 @@ pub fn router(state: SharedState) -> Router {
     Router::new()
         .route("/ping", get(ping))
         .route("/health", get(health))
+        .route("/printers", get(list_printers))
         .route("/status/:device_id", get(get_status))
         .route("/ams/:device_id", get(get_ams))
         .route("/print", axum::routing::post(start_print))
@@ -610,6 +679,34 @@ mod tests {
         assert_eq!(trays[0]["tray_type"], "PLA");
         assert_eq!(trays[1]["tray_type"], "ASA");
         assert_eq!(body["vt_tray"]["tray_type"], "TPU");
+    }
+
+    #[tokio::test]
+    async fn printers_lists_configured_printers() {
+        let mut devices = HashMap::new();
+        devices.insert("DEV001".into(), sample_status());
+        let printers = vec![
+            ("workshop".to_string(), "DEV001".to_string()),
+            ("office".to_string(), "DEV002".to_string()),
+        ];
+        let state = mock_state_with_printers(devices, printers);
+        let app = router(state);
+        let server = axum_test::TestServer::new(app).unwrap();
+
+        let resp = server.get("/printers").await;
+        resp.assert_status_ok();
+        let body: serde_json::Value = resp.json();
+        let printers = body["printers"].as_array().unwrap();
+        assert_eq!(printers.len(), 2);
+        // First printer has cached status
+        assert_eq!(printers[0]["name"], "workshop");
+        assert_eq!(printers[0]["serial"], "DEV001");
+        assert_eq!(printers[0]["cached"], true);
+        assert_eq!(printers[0]["gcode_state"], "RUNNING");
+        // Second printer has no cached status
+        assert_eq!(printers[1]["name"], "office");
+        assert_eq!(printers[1]["serial"], "DEV002");
+        assert_eq!(printers[1]["cached"], false);
     }
 
     #[tokio::test]

--- a/changes/41.feature
+++ b/changes/41.feature
@@ -1,0 +1,1 @@
+Default credentials to ~/.config/estampo/credentials.toml, add --credentials flag

--- a/changes/42.feature
+++ b/changes/42.feature
@@ -1,0 +1,1 @@
+Auto-detect printers when no device ID given, add /printers daemon endpoint

--- a/changes/43.bugfix
+++ b/changes/43.bugfix
@@ -1,0 +1,1 @@
+Fix platform detection in auto-fetch: send correct X-BBL-OS-Type header to Bambu API


### PR DESCRIPTION
## Summary
- **#41**: Default credentials to `~/.config/estampo/credentials.toml`. Added `--credentials`/`-c` global flag and `BAMBU_CREDENTIALS` env var. Credentials removed as positional arg from all subcommands.
- **#42**: `status` without a device ID auto-detects printers from `[printers.*]` sections and queries all of them. New `/printers` daemon endpoint returns configured printers with cached status summary.
- **#43**: Auto-fetch now sends the correct `X-BBL-OS-Type` header (`linux`/`macos`/`windows`) so Bambu's API returns the right platform's plugin ZIP. Also uses `BambuStudio/{version}` User-Agent to match OrcaSlicer behavior.

Closes #41, closes #42, closes #43

## Test plan
- [ ] CI build passes on all 3 platforms
- [ ] `bambu-bridge status` (no args) discovers printers from credentials and shows status
- [ ] `bambu-bridge status <device_id>` still works
- [ ] `bambu-bridge --credentials /path/to/creds.toml status` works
- [ ] `bambu-bridge daemon` → `curl localhost:8765/printers` returns printer list
- [ ] macOS auto-fetch downloads `.dylib` not `.dll`

🤖 Generated with [Claude Code](https://claude.com/claude-code)