### PR TITLE
Rename bridge to bambox-bridge, CI on changes, xattr fix

### DIFF
--- a/.github/workflows/build-bridge.yml
+++ b/.github/workflows/build-bridge.yml
@@ -3,6 +3,13 @@ name: Build bridge binaries
 on:
   push:
     tags: ['v*']
+    paths:
+      - 'bridge/**'
+    branches:
+      - main
+  pull_request:
+    paths:
+      - 'bridge/**'
   workflow_dispatch:
 
 jobs:
@@ -12,13 +19,13 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            artifact: bambu-bridge-linux-x86_64
+            artifact: bambox-bridge-linux-x86_64
           - target: x86_64-apple-darwin
             os: macos-15
-            artifact: bambu-bridge-macos-x86_64
+            artifact: bambox-bridge-macos-x86_64
           - target: aarch64-apple-darwin
             os: macos-14
-            artifact: bambu-bridge-macos-arm64
+            artifact: bambox-bridge-macos-arm64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -34,12 +41,12 @@ jobs:
       - name: Package binary
         run: |
           mkdir -p dist
-          cp bridge/target/${{ matrix.target }}/release/bambu-bridge dist/${{ matrix.artifact }}
-          chmod +x dist/${{ matrix.artifact }}
+          cp bridge/target/${{ matrix.target }}/release/bambox-bridge dist/bambox-bridge
+          chmod +x dist/bambox-bridge
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
-          path: dist/${{ matrix.artifact }}
+          path: dist/bambox-bridge
 
   release-assets:
     needs: build-bridge
@@ -51,12 +58,14 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: dist
-          merge-multiple: true
       - name: Upload to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG=${GITHUB_REF#refs/tags/}
-          for f in dist/*; do
-            gh release upload "$TAG" "$f" --repo "${{ github.repository }}" --clobber
+          for dir in dist/bambox-bridge-*; do
+            name=$(basename "$dir")
+            mv "$dir/bambox-bridge" "dist/$name"
+            rmdir "$dir"
+            gh release upload "$TAG" "dist/$name" --repo "${{ github.repository }}" --clobber
           done

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "bambu-bridge"
+name = "bambox-bridge"
 version = "0.1.0"
 edition = "2021"
 description = "Rust bridge daemon for Bambu Lab printers via libbambu_networking.so"

--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -85,11 +85,11 @@ RUN mkdir -p /tmp/bambu_agent/cert /tmp/bambu_agent/log /tmp/bambu_agent/config 
     && curl -fSL -o /tmp/bambu_agent/cert/slicer_base64.cer \
        "https://raw.githubusercontent.com/bambulab/BambuStudio/master/resources/cert/slicer_base64.cer"
 
-COPY --from=builder /build/target/release/bambu-bridge /usr/local/bin/bambu-bridge
+COPY --from=builder /build/target/release/bambox-bridge /usr/local/bin/bambox-bridge
 
 ENV BAMBU_LIB_PATH=/tmp/bambu_plugin/libbambu_networking.so
 
 EXPOSE 8765
 
-ENTRYPOINT ["bambu-bridge"]
+ENTRYPOINT ["bambox-bridge"]
 CMD ["daemon", "--bind", "0.0.0.0", "--port", "8765", "--credentials", "/config/credentials.toml"]

--- a/bridge/src/fetch.rs
+++ b/bridge/src/fetch.rs
@@ -198,7 +198,7 @@ fn find_plugin_url(json: &serde_json::Value) -> Result<String, String> {
 /// Download a URL and return the bytes.
 async fn download_file(url: &str) -> Result<Vec<u8>, String> {
     let client = reqwest::Client::builder()
-        .user_agent("bambu-bridge/0.1")
+        .user_agent("bambox-bridge/0.1")
         .build()
         .map_err(|e| format!("HTTP client error: {e}"))?;
 

--- a/bridge/src/main.rs
+++ b/bridge/src/main.rs
@@ -29,7 +29,7 @@ fn default_credentials_path() -> PathBuf {
 }
 
 #[derive(Parser)]
-#[command(name = "bambu-bridge", about = "Bambu Lab printer bridge")]
+#[command(name = "bambox-bridge", about = "Bambu Lab printer bridge")]
 struct Cli {
     #[command(subcommand)]
     command: Command,

--- a/changes/+bridge-rename.misc
+++ b/changes/+bridge-rename.misc
@@ -1,0 +1,1 @@
+Rename bridge binary to bambox-bridge, add xattr fix for macOS, trigger CI on bridge changes

--- a/docs/daemon-bridge-design.md
+++ b/docs/daemon-bridge-design.md
@@ -144,7 +144,7 @@ def start_daemon(credentials_path=None):
     """Start the bridge daemon container."""
     subprocess.run([
         "docker", "run", "-d",
-        "--name", "bambu-bridge",
+        "--name", "bambox-bridge",
         "--restart", "unless-stopped",
         "-p", "8765:8765",
         "-v", f"{credentials_path}:/config/credentials.json:ro",
@@ -152,8 +152,8 @@ def start_daemon(credentials_path=None):
     ])
 
 def stop_daemon():
-    subprocess.run(["docker", "stop", "bambu-bridge"])
-    subprocess.run(["docker", "rm", "bambu-bridge"])
+    subprocess.run(["docker", "stop", "bambox-bridge"])
+    subprocess.run(["docker", "rm", "bambox-bridge"])
 
 def ensure_daemon(credentials_path=None):
     """Start daemon if not running."""

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Install bambu-bridge — standalone Bambu Lab printer bridge
+# Install bambox-bridge — standalone Bambu Lab printer bridge
 set -e
 
 REPO="estampo/bambox"
@@ -21,7 +21,7 @@ case "$ARCH" in
   *)             echo "Unsupported architecture: $ARCH"; exit 1 ;;
 esac
 
-BINARY="bambu-bridge-${PLATFORM}-${ARCH_TAG}"
+ARTIFACT="bambox-bridge-${PLATFORM}-${ARCH_TAG}"
 
 # Get latest release tag
 TAG=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | head -1 | cut -d'"' -f4)
@@ -30,20 +30,25 @@ if [ -z "$TAG" ]; then
   exit 1
 fi
 
-URL="https://github.com/${REPO}/releases/download/${TAG}/${BINARY}"
+URL="https://github.com/${REPO}/releases/download/${TAG}/${ARTIFACT}"
 
-echo "Downloading bambu-bridge ${TAG} for ${PLATFORM}/${ARCH_TAG}..."
+echo "Downloading bambox-bridge ${TAG} for ${PLATFORM}/${ARCH_TAG}..."
 mkdir -p "$INSTALL_DIR"
-curl -fsSL -o "${INSTALL_DIR}/bambu-bridge" "$URL"
-chmod +x "${INSTALL_DIR}/bambu-bridge"
+curl -fsSL -o "${INSTALL_DIR}/bambox-bridge" "$URL"
+chmod +x "${INSTALL_DIR}/bambox-bridge"
+
+# macOS: remove quarantine attribute to avoid Gatekeeper prompts
+if [ "$OS" = "Darwin" ]; then
+  xattr -d com.apple.quarantine "${INSTALL_DIR}/bambox-bridge" 2>/dev/null || true
+fi
 
 echo ""
-echo "Installed bambu-bridge to ${INSTALL_DIR}/bambu-bridge"
+echo "Installed bambox-bridge to ${INSTALL_DIR}/bambox-bridge"
 echo ""
 if ! echo "$PATH" | tr ':' '\n' | grep -q "^${INSTALL_DIR}$"; then
   echo "Add ${INSTALL_DIR} to your PATH:"
   echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
   echo ""
 fi
-echo "Run 'bambu-bridge --help' to get started."
+echo "Run 'bambox-bridge --help' to get started."
 echo "The Bambu networking library will be downloaded automatically on first use."


### PR DESCRIPTION
## Summary
- Rename binary from `bambu-bridge` to `bambox-bridge` across Cargo.toml, Dockerfile, CLI, docs, and install script
- CI build-bridge workflow now triggers on `bridge/**` changes (push to main + PRs), not just version tags
- Release artifacts use platform in the artifact name (e.g. `bambox-bridge-macos-arm64`), binary inside is always `bambox-bridge`
- `install.sh` strips macOS quarantine attribute via `xattr -d` to avoid Gatekeeper popups
- Filed #45 for Homebrew tap distribution (future)

## Test plan
- [ ] CI builds all 3 platforms on this PR (triggered by bridge/ changes)
- [ ] `install.sh` downloads and installs correctly
- [ ] Docker build uses new binary name

🤖 Generated with [Claude Code](https://claude.com/claude-code)