### PR TITLE
Wire settings into pack CLI

### DIFF
--- a/changes/+wire-settings-pack.feature
+++ b/changes/+wire-settings-pack.feature
@@ -1,0 +1,1 @@
+Wire settings.py into pack CLI: auto-generate 544-key project_settings from machine and filament profiles

--- a/src/bambox/cli.py
+++ b/src/bambox/cli.py
@@ -9,6 +9,25 @@ import sys
 from pathlib import Path
 
 from bambox.pack import FilamentInfo, SliceInfo, pack_gcode_3mf
+from bambox.settings import available_filaments, available_machines, build_project_settings
+
+
+def _parse_filament_args(
+    filament_args: list[str] | None,
+) -> list[tuple[str, str]]:
+    """Parse --filament TYPE or --filament TYPE:COLOR into (type, color) pairs."""
+    if not filament_args:
+        return [("PLA", "#F2754E")]
+    result = []
+    for spec in filament_args:
+        if ":" in spec:
+            ftype, color = spec.split(":", 1)
+            if not color.startswith("#"):
+                color = "#" + color
+            result.append((ftype.upper(), color))
+        else:
+            result.append((spec.upper(), "#F2754E"))
+    return result
 
 
 def _cmd_pack(args: argparse.Namespace) -> None:
@@ -20,19 +39,37 @@ def _cmd_pack(args: argparse.Namespace) -> None:
     output = args.output or args.gcode.with_suffix(".gcode.3mf")
     gcode = args.gcode.read_bytes()
 
+    filaments = _parse_filament_args(args.filament)
+    filament_types = [f[0] for f in filaments]
+    filament_colors = [f[1] for f in filaments]
+
+    filament_infos = [
+        FilamentInfo(
+            slot=i + 1,
+            filament_type=ftype,
+            color=color,
+        )
+        for i, (ftype, color) in enumerate(filaments)
+    ]
+
     info = SliceInfo(
         printer_model_id=args.printer_model_id,
         nozzle_diameter=args.nozzle_diameter,
-        filaments=[
-            FilamentInfo(
-                slot=1,
-                filament_type=args.filament_type,
-                color=args.filament_color,
-            )
-        ],
+        filaments=filament_infos,
     )
 
-    pack_gcode_3mf(gcode, output, slice_info=info)
+    # Generate project_settings from machine + filament profiles
+    try:
+        project_settings = build_project_settings(
+            filament_types,
+            machine=args.machine,
+            filament_colors=filament_colors,
+        )
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    pack_gcode_3mf(gcode, output, slice_info=info, project_settings=project_settings)
     print(f"Wrote {output} ({output.stat().st_size} bytes)")
 
 
@@ -165,10 +202,22 @@ def main(argv: list[str] | None = None) -> None:
     pack_p = sub.add_parser("pack", help="Package G-code into .gcode.3mf")
     pack_p.add_argument("gcode", type=Path, help="Input G-code file")
     pack_p.add_argument("-o", "--output", type=Path, help="Output .gcode.3mf path")
+    pack_p.add_argument(
+        "-m",
+        "--machine",
+        default="p1s",
+        help=f"Machine profile ({', '.join(available_machines())})",
+    )
+    pack_p.add_argument(
+        "-f",
+        "--filament",
+        action="append",
+        metavar="TYPE[:COLOR]",
+        help=f"Filament type, optionally with color (e.g. 'PETG-CF' or 'PLA:#FF0000'). "
+        f"Repeatable for multi-filament. Available: {', '.join(available_filaments())}",
+    )
     pack_p.add_argument("--printer-model-id", default="")
     pack_p.add_argument("--nozzle-diameter", type=float, default=0.4)
-    pack_p.add_argument("--filament-type", default="PLA")
-    pack_p.add_argument("--filament-color", default="#F2754E")
 
     # --- print subcommand ---
     print_p = sub.add_parser("print", help="Send .gcode.3mf to printer via cloud bridge")
@@ -221,10 +270,10 @@ def main(argv: list[str] | None = None) -> None:
             ns = argparse.Namespace(
                 gcode=Path(argv[0]),
                 output=None,
+                machine="p1s",
+                filament=None,
                 printer_model_id="",
                 nozzle_diameter=0.4,
-                filament_type="PLA",
-                filament_color="#F2754E",
                 verbose=False,
             )
             _cmd_pack(ns)

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -16,6 +16,7 @@ from io import BytesIO
 from pathlib import Path
 
 from bambox.assemble import assemble_gcode
+from bambox.cli import _parse_filament_args, main
 from bambox.pack import FilamentInfo, SliceInfo, pack_gcode_3mf
 from bambox.templates import render_template
 
@@ -248,3 +249,88 @@ class TestEndToEnd:
         end_pos = gcode.index(";===== date: 20230428")
 
         assert start_pos < toolpath_pos < end_pos
+
+
+class TestParseFilamentArgs:
+    def test_default_when_none(self) -> None:
+        result = _parse_filament_args(None)
+        assert result == [("PLA", "#F2754E")]
+
+    def test_single_type(self) -> None:
+        result = _parse_filament_args(["PETG-CF"])
+        assert result == [("PETG-CF", "#F2754E")]
+
+    def test_type_with_color(self) -> None:
+        result = _parse_filament_args(["PLA:#FF0000"])
+        assert result == [("PLA", "#FF0000")]
+
+    def test_color_without_hash(self) -> None:
+        result = _parse_filament_args(["ASA:BCBCBC"])
+        assert result == [("ASA", "#BCBCBC")]
+
+    def test_multiple_filaments(self) -> None:
+        result = _parse_filament_args(["PETG-CF:#2850E0", "PLA"])
+        assert result == [("PETG-CF", "#2850E0"), ("PLA", "#F2754E")]
+
+    def test_lowercase_normalized(self) -> None:
+        result = _parse_filament_args(["pla"])
+        assert result == [("PLA", "#F2754E")]
+
+
+class TestCliPack:
+    def test_pack_generates_project_settings(self, tmp_path: Path) -> None:
+        """CLI pack should auto-generate project_settings from machine+filament."""
+        gcode_file = tmp_path / "test.gcode"
+        gcode_file.write_text("G28\nG1 Z0.2 F1200\nG1 X10 Y10 E1 F600\n")
+        output = tmp_path / "test.gcode.3mf"
+
+        main(["pack", str(gcode_file), "-o", str(output), "-f", "PLA"])
+
+        assert output.exists()
+        with zipfile.ZipFile(output) as z:
+            names = z.namelist()
+            assert "Metadata/project_settings.config" in names
+            ps = json.loads(z.read("Metadata/project_settings.config"))
+            # Should have 544+ keys
+            assert len(ps) > 500
+            # Arrays padded to 5
+            for key, val in ps.items():
+                if isinstance(val, list) and len(val) > 0:
+                    assert len(val) >= 5
+
+    def test_pack_multi_filament(self, tmp_path: Path) -> None:
+        gcode_file = tmp_path / "multi.gcode"
+        gcode_file.write_text("G28\nG1 Z0.2 F1200\nG1 X10 Y10 E1 F600\n")
+        output = tmp_path / "multi.gcode.3mf"
+
+        main(
+            [
+                "pack",
+                str(gcode_file),
+                "-o",
+                str(output),
+                "-f",
+                "PETG-CF:#2850E0",
+                "-f",
+                "PLA:#000000",
+            ]
+        )
+
+        with zipfile.ZipFile(output) as z:
+            ps = json.loads(z.read("Metadata/project_settings.config"))
+            # filament_colour should have our colors
+            colors = ps["filament_colour"]
+            assert colors[0] == "#2850E0"
+            assert colors[1] == "#000000"
+
+    def test_pack_default_filament(self, tmp_path: Path) -> None:
+        """Pack with no --filament flag defaults to PLA."""
+        gcode_file = tmp_path / "default.gcode"
+        gcode_file.write_text("G28\nG1 Z0.2 F1200\nG1 X10 Y10 E1 F600\n")
+        output = tmp_path / "default.gcode.3mf"
+
+        main(["pack", str(gcode_file), "-o", str(output)])
+
+        with zipfile.ZipFile(output) as z:
+            ps = json.loads(z.read("Metadata/project_settings.config"))
+            assert len(ps) > 500


### PR DESCRIPTION
## Summary
`bambox pack` now auto-generates the 544-key `project_settings.config` from machine and filament profiles.

**Before:** `bambox pack file.gcode` produced an archive with no project_settings (firmware may reject it).

**After:** `bambox pack file.gcode -f PETG-CF` produces a complete archive with all 544 settings keys, arrays padded to 5 slots, ready for Bambu Connect.

### Usage
```
bambox pack file.gcode                          # defaults to PLA on P1S
bambox pack file.gcode -f PETG-CF               # single filament
bambox pack file.gcode -f PETG-CF:#2850E0       # with color
bambox pack file.gcode -f PLA -f ASA:#BCBCBC    # multi-filament
bambox pack file.gcode -m p1s -f PLA            # explicit machine
```

### Changes
- `--filament/-f` repeatable flag (TYPE or TYPE:COLOR), replaces old `--filament-type`/`--filament-color`
- `--machine/-m` flag (default: p1s)
- `build_project_settings()` called automatically
- 9 new tests for CLI pack and filament arg parsing

Partial work on #27

## Test plan
- [x] 102 tests pass locally (9 new)
- [x] mypy clean
- [x] ruff clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)