### PR TITLE
Add M73 P100 R0 to end G-code for print completion

### DIFF
--- a/changes/56.bugfix
+++ b/changes/56.bugfix
@@ -1,0 +1,1 @@
+Add M73 P100 R0 to end G-code so the printer transitions to 100% complete instead of staying stuck at 99%.

--- a/src/bambox/gcode_templates/p1s_end.gcode.j2
+++ b/src/bambox/gcode_templates/p1s_end.gcode.j2
@@ -49,6 +49,7 @@ M17 R ; restore z current
 M220 S100  ; Reset feedrate magnitude
 M201.2 K1.0 ; Reset acc magnitude
 M73.2   R1.0 ;Reset left time magnitude
+M73 P100 R0 ; signal 100% complete — without this the printer stays stuck at 99%
 M1002 set_gcode_claim_speed_level : 0
 
 M17 X0.8 Y0.8 Z0.5 ; lower motor current to 45% power

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -186,6 +186,16 @@ class TestRenderTemplate:
         # max_layer_z + 100 = 200 < 250, should use the calculated value
         assert "G1 Z200 F600" in result
 
+    def test_p1s_end_signals_completion(self) -> None:
+        """End gcode must include M73 P100 R0 so printer transitions to 100%."""
+        result = render_template(
+            "p1s_end.gcode.j2",
+            {
+                "max_layer_z": 20.0,
+            },
+        )
+        assert "M73 P100 R0" in result
+
     def test_p1s_end_z_retract_clamped(self) -> None:
         """End gcode clamps Z at 250 for tall prints."""
         result = render_template(


### PR DESCRIPTION
## Summary
- Adds `M73 P100 R0` to `p1s_end.gcode.j2` so the printer transitions to 100% complete instead of staying stuck at 99%
- The layer progress markers (`M73 P{pct}`) are injected at each layer change but nothing ever sent the final 100% — BambuStudio includes this in its end G-code, bambox was missing it

Fixes #56

## Test plan
- [x] New test `test_p1s_end_signals_completion` verifies `M73 P100 R0` is present in rendered end G-code
- [x] All 143 tests pass
- [ ] Print a job and confirm printer shows 100% and transitions to idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)