### PR TITLE
Add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # bambox
 
+[![CI](https://github.com/estampo/bambox/actions/workflows/ci.yml/badge.svg)](https://github.com/estampo/bambox/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/estampo/bambox/branch/main/graph/badge.svg)](https://codecov.io/gh/estampo/bambox)
+[![PyPI version](https://img.shields.io/pypi/v/bambu-3mf)](https://pypi.org/project/bambu-3mf/)
+[![Python versions](https://img.shields.io/pypi/pyversions/bambu-3mf)](https://pypi.org/project/bambu-3mf/)
+
 Package plain G-code into Bambu Lab `.gcode.3mf` files — no OrcaSlicer required.
 
 `bambox` is a standalone Python library for creating printer-ready Bambu Lab

--- a/changes/15.misc
+++ b/changes/15.misc
@@ -1,0 +1,1 @@
+Add CI, coverage, PyPI, and Python version badges to README


### PR DESCRIPTION
## Summary
- Add shields.io badges to README: CI status, code coverage (codecov), PyPI version, and Python versions
- Closes #15

## Test plan
- [ ] Verify badges render correctly on GitHub
- [ ] Confirm badge links point to correct targets (CI workflow, codecov, PyPI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)