### PR TITLE
Fix bridge static-mut UB, cstr lifetime, single-agent docs

### DIFF
--- a/bridge/shim/shim.cpp
+++ b/bridge/shim/shim.cpp
@@ -288,6 +288,14 @@ int bambu_shim_send_message_to_printer(
 //
 // Each stores a C function pointer + void* context, wraps it in a
 // std::function, and passes it to the real .so function.
+//
+// IMPORTANT: Single-agent constraint
+// The callback function pointers and context pointers (g_server_cb,
+// g_message_cb, etc.) are file-scoped globals. This means only ONE agent
+// instance can have callbacks registered at a time. If a second agent
+// calls these setters, it silently overwrites the first agent's callbacks.
+// This is acceptable because the Bambu networking .so itself only supports
+// one agent per process.
 // ---------------------------------------------------------------------------
 
 // on_server_connected(int rc, int reason)

--- a/bridge/src/agent.rs
+++ b/bridge/src/agent.rs
@@ -165,6 +165,14 @@ impl Credentials {
 }
 
 /// High-level agent wrapping the C++ shim + .so library.
+///
+/// # Single-instance constraint
+///
+/// Only one `BambuAgent` may exist per process. The C++ shim (`shim.cpp`)
+/// stores callback function pointers and context pointers in file-scoped
+/// globals, so creating a second agent would silently overwrite the first
+/// agent's callbacks and lead to undefined behavior. This is a fundamental
+/// limitation of the Bambu networking library's callback registration API.
 pub struct BambuAgent {
     agent: *mut c_void,
     // Box to ensure stable address for callback context pointer

--- a/bridge/src/callbacks.rs
+++ b/bridge/src/callbacks.rs
@@ -10,6 +10,14 @@ use std::sync::Mutex;
 
 /// Shared state for all callbacks. Allocated on the heap and passed as the
 /// `void* ctx` to every shim callback setter.
+///
+/// # Single-agent constraint
+///
+/// The underlying C++ shim stores callback function pointers and context
+/// pointers in file-scoped globals (`g_message_cb`, `g_server_cb`, etc.).
+/// This means only one `CallbackState` (and therefore one `BambuAgent`)
+/// can be active in a process at a time. Registering callbacks from a
+/// second agent would silently overwrite the first agent's callbacks.
 pub struct CallbackState {
     pub server_connected: AtomicBool,
     pub user_logged_in: AtomicBool,
@@ -48,11 +56,11 @@ unsafe fn state(ctx: *mut c_void) -> &'static CallbackState {
     &*(ctx as *const CallbackState)
 }
 
-unsafe fn cstr_to_str(ptr: *const c_char) -> &'static str {
+unsafe fn cstr_to_string(ptr: *const c_char) -> String {
     if ptr.is_null() {
-        return "";
+        return String::new();
     }
-    CStr::from_ptr(ptr).to_str().unwrap_or("")
+    CStr::from_ptr(ptr).to_str().unwrap_or("").to_owned()
 }
 
 pub extern "C" fn on_server_connected(rc: c_int, _reason: c_int, ctx: *mut c_void) {
@@ -65,24 +73,24 @@ pub extern "C" fn on_server_connected(rc: c_int, _reason: c_int, ctx: *mut c_voi
 
 pub extern "C" fn on_message(dev_id: *const c_char, msg: *const c_char, ctx: *mut c_void) {
     let s = unsafe { state(ctx) };
-    let dev = unsafe { cstr_to_str(dev_id) };
-    let payload = unsafe { cstr_to_str(msg) };
+    let dev = unsafe { cstr_to_string(dev_id) };
+    let payload = unsafe { cstr_to_string(msg) };
     if payload.is_empty() || payload == "{}" {
         return;
     }
-    tracing::trace!(dev_id = dev, len = payload.len(), "mqtt message");
+    tracing::trace!(dev_id = &*dev, len = payload.len(), "mqtt message");
     let mut lock = s.messages.lock().unwrap();
     lock.push(MqttMessage {
-        dev_id: dev.to_owned(),
-        payload: payload.to_owned(),
+        dev_id: dev,
+        payload,
     });
 }
 
 pub extern "C" fn on_printer_connected(topic: *const c_char, ctx: *mut c_void) {
     let s = unsafe { state(ctx) };
     s.printer_subscribed.store(true, Ordering::SeqCst);
-    let t = unsafe { cstr_to_str(topic) };
-    tracing::debug!(topic = t, "printer_connected callback");
+    let t = unsafe { cstr_to_string(topic) };
+    tracing::debug!(topic = &*t, "printer_connected callback");
 }
 
 pub extern "C" fn on_user_login(_online: c_int, login: c_int, ctx: *mut c_void) {
@@ -94,13 +102,13 @@ pub extern "C" fn on_user_login(_online: c_int, login: c_int, ctx: *mut c_void) 
 }
 
 pub extern "C" fn on_http_error(code: c_uint, body: *const c_char, _ctx: *mut c_void) {
-    let b = unsafe { cstr_to_str(body) };
+    let b = unsafe { cstr_to_string(body) };
     tracing::warn!(code, body = &b[..b.len().min(200)], "http_error callback");
 }
 
 pub extern "C" fn on_subscribe_failure(topic: *const c_char, _ctx: *mut c_void) {
-    let t = unsafe { cstr_to_str(topic) };
-    tracing::warn!(topic = t, "subscribe_failure callback");
+    let t = unsafe { cstr_to_string(topic) };
+    tracing::warn!(topic = &*t, "subscribe_failure callback");
 }
 
 // ---------------------------------------------------------------------------

--- a/bridge/src/main.rs
+++ b/bridge/src/main.rs
@@ -14,6 +14,7 @@ use std::io::{self, BufRead, Write};
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::process;
+use std::sync::atomic::{AtomicI32, Ordering};
 use std::time::Duration;
 
 use clap::{Parser, Subcommand};
@@ -94,13 +95,13 @@ enum Command {
 }
 
 /// Saved original stdout fd, used to restore after suppressing library noise.
-static mut SAVED_STDOUT: i32 = -1;
+static SAVED_STDOUT: AtomicI32 = AtomicI32::new(-1);
 
 /// Suppress stdout to hide library noise (e.g. "use_count = 4").
 /// Logs (tracing) go to stderr and are unaffected.
 fn suppress_stdout() {
     unsafe {
-        SAVED_STDOUT = libc::dup(1);
+        SAVED_STDOUT.store(libc::dup(1), Ordering::SeqCst);
         let devnull = libc::open(b"/dev/null\0".as_ptr() as *const _, libc::O_WRONLY);
         if devnull >= 0 {
             libc::dup2(devnull, 1);
@@ -112,8 +113,9 @@ fn suppress_stdout() {
 /// Restore stdout after suppression.
 fn restore_stdout() {
     unsafe {
-        if SAVED_STDOUT >= 0 {
-            libc::dup2(SAVED_STDOUT, 1);
+        let fd = SAVED_STDOUT.load(Ordering::SeqCst);
+        if fd >= 0 {
+            libc::dup2(fd, 1);
         }
     }
 }

--- a/changes/+bridge-mechanical.misc
+++ b/changes/+bridge-mechanical.misc
@@ -1,0 +1,1 @@
+Bridge: fix static-mut UB, cstr_to_str lifetime, document single-agent constraint.


### PR DESCRIPTION
## Summary

- Replace `static mut SAVED_STDOUT` with `AtomicI32` to eliminate undefined behavior from unsynchronized mutable static access
- Change `cstr_to_str` (returning `&'static str`) to `cstr_to_string` (returning owned `String`) to fix unsound lifetime — the C strings may not live past the callback invocation
- Document the single-agent constraint on `BambuAgent`, `CallbackState`, and the shim callback section

Part of #28 (1 of 4).

## Test plan
- [x] `cargo check` passes (bridge compiles clean, pre-existing `dead_code` warning only)
- [x] `ruff check` / `ruff format --check` / `mypy` / `pytest` all pass
- [x] Towncrier fragment added

🤖 Generated with [Claude Code](https://claude.com/claude-code)