### PR TITLE
Wire up print cancellation for Rust bridge

### DIFF
--- a/bridge/shim/shim.cpp
+++ b/bridge/shim/shim.cpp
@@ -8,6 +8,7 @@
  * The library is loaded at runtime via dlopen — no compile-time linking needed.
  */
 
+#include <atomic>
 #include <cstring>
 #include <dlfcn.h>
 #include <functional>
@@ -413,6 +414,25 @@ int bambu_shim_set_on_subscribe_failure_fn(
 }
 
 // ---------------------------------------------------------------------------
+// Upload cancellation
+//
+// Global atomic flag checked by WasCancelledFn during file transfer.
+// The Rust side calls request_cancel() from the /cancel endpoint and
+// reset_cancel() before each new print. This follows the same global
+// pattern used by the callback setters above (single-agent constraint).
+// ---------------------------------------------------------------------------
+
+static std::atomic<bool> g_cancel_requested{false};
+
+void bambu_shim_request_cancel() {
+    g_cancel_requested.store(true, std::memory_order_seq_cst);
+}
+
+void bambu_shim_reset_cancel() {
+    g_cancel_requested.store(false, std::memory_order_seq_cst);
+}
+
+// ---------------------------------------------------------------------------
 // Print support
 // ---------------------------------------------------------------------------
 
@@ -517,7 +537,9 @@ int bambu_shim_start_print(
         else if (status == 7) { result->print_result = code; result->finished = 1; }
     };
 
-    WasCancelledFn cancel_fn = []() -> bool { return false; };
+    WasCancelledFn cancel_fn = []() -> bool {
+        return g_cancel_requested.load(std::memory_order_seq_cst);
+    };
     OnWaitFn wait_fn = [](int, std::string) -> bool { return false; };
 
     result->return_code = fp_start_print(agent, params, update_fn, cancel_fn, wait_fn);

--- a/bridge/src/agent.rs
+++ b/bridge/src/agent.rs
@@ -535,6 +535,10 @@ impl BambuAgent {
             result.print_result = -999;
             result.finished = 0;
 
+            // Reset cancel flag before each attempt so a stale cancel
+            // from a previous job doesn't abort this one.
+            unsafe { ffi::bambu_shim_reset_cancel() };
+
             let ret = unsafe {
                 ffi::bambu_shim_start_print(
                     self.agent,

--- a/bridge/src/ffi.rs
+++ b/bridge/src/ffi.rs
@@ -139,6 +139,10 @@ extern "C" {
         ctx: *mut c_void,
     ) -> c_int;
 
+    // Upload cancellation
+    pub fn bambu_shim_request_cancel();
+    pub fn bambu_shim_reset_cancel();
+
     // Print
     pub fn bambu_shim_start_print(
         agent: *mut c_void,

--- a/bridge/src/handle.rs
+++ b/bridge/src/handle.rs
@@ -37,6 +37,9 @@ pub enum AgentCommand {
         request: PrintRequest,
         reply: oneshot::Sender<Result<PrintResult, String>>,
     },
+    CancelUpload {
+        reply: oneshot::Sender<()>,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -98,6 +101,16 @@ impl AgentHandle {
             .await
             .map_err(|_| "agent thread gone".to_string())?;
         rx.await.map_err(|_| "agent thread dropped reply".to_string())?
+    }
+
+    /// Request cancellation of an in-flight upload.
+    pub async fn cancel_upload(&self) -> Result<(), String> {
+        let (reply, rx) = oneshot::channel();
+        self.tx
+            .send(AgentCommand::CancelUpload { reply })
+            .await
+            .map_err(|_| "agent thread gone".to_string())?;
+        rx.await.map_err(|_| "agent thread dropped reply".to_string())
     }
 
     /// Start a cloud print job.
@@ -191,6 +204,11 @@ pub fn spawn_agent_thread(agent: BambuAgent) -> AgentHandle {
                     AgentCommand::StartPrint { request, reply } => {
                         let result = agent.start_print(&request);
                         let _ = reply.send(result);
+                    }
+                    AgentCommand::CancelUpload { reply } => {
+                        unsafe { crate::ffi::bambu_shim_request_cancel() };
+                        tracing::info!("upload cancellation requested");
+                        let _ = reply.send(());
                     }
                 }
 

--- a/bridge/src/server.rs
+++ b/bridge/src/server.rs
@@ -289,6 +289,11 @@ async fn cancel_print(
     State(state): State<SharedState>,
     Path(device_id): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+    // Abort any in-flight file upload first — this sets the global cancel
+    // flag that WasCancelledFn checks during the FTP transfer.
+    let upload_cancelled = state.handle.cancel_upload().await.is_ok();
+
+    // Send the MQTT stop command to halt the printer itself.
     let stop_cmd = r#"{"print":{"command":"stop","sequence_id":"0"}}"#;
     let ret = state
         .handle
@@ -312,6 +317,7 @@ async fn cancel_print(
         "command": "stop",
         "device_id": device_id,
         "sent": true,
+        "upload_cancelled": upload_cancelled,
     })))
 }
 

--- a/changes/+bridge-cancel.feature
+++ b/changes/+bridge-cancel.feature
@@ -1,0 +1,1 @@
+Bridge: wire up print cancellation to abort in-flight uploads.


### PR DESCRIPTION
## Summary
- Add global `std::atomic<bool>` cancel flag in `shim.cpp` with `bambu_shim_request_cancel()` / `bambu_shim_reset_cancel()` FFI functions
- Wire `WasCancelledFn` lambda to read the cancel flag instead of always returning `false`
- Add `CancelUpload` command to the agent channel; `/cancel` endpoint now aborts in-flight uploads in addition to sending the MQTT stop command
- Reset cancel flag before each print attempt to prevent stale cancellations

Part 4 of 4 for the Rust bridge migration. Closes #28.

## Test plan
- [ ] `cargo check` passes (verified locally)
- [ ] Python lint/format/type/test checks pass (verified locally — 27 failures are pre-existing jinja2 dep)
- [ ] Manual: start a large print upload, hit `/cancel/:device_id`, verify upload aborts
- [ ] Manual: verify normal prints still complete after a previous cancel

🤖 Generated with [Claude Code](https://claude.com/claude-code)