### PR TITLE
Fix Hatchling config to include bambox package in built wheels

### DIFF
--- a/changes/+fix-packaging.bugfix
+++ b/changes/+fix-packaging.bugfix
@@ -1,0 +1,1 @@
+Fix Hatchling config so built wheels include the bambox package.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+packages = ["src/bambox"]
+
 [project]
 name = "bambox"
 version = "0.1.0"


### PR DESCRIPTION
## Summary
- Add `[tool.hatch.build.targets.wheel]` section to `pyproject.toml` with `packages = ["src/bambox"]` so Hatchling discovers the src-layout package
- Without this, built wheels contained only dist-info metadata and no importable `bambox` module

## Test plan
- [x] `uv run pytest` — 172 tests pass
- [x] `uv run ruff check src tests` — clean
- [x] `uv run ruff format --check src tests` — clean
- [x] `uv run mypy src/bambox` — clean
- [x] `uv build --wheel` produces a wheel containing `bambox/` with all modules and data files

🤖 Generated with [Claude Code](https://claude.com/claude-code)