### PR TITLE
Fix shallow copy mutation in fixup_project_settings

### DIFF
--- a/changes/+fix-settings-copy.bugfix
+++ b/changes/+fix-settings-copy.bugfix
@@ -1,0 +1,1 @@
+fixup_project_settings() no longer mutates caller-owned dicts or shared defaults.

--- a/src/bambox/pack.py
+++ b/src/bambox/pack.py
@@ -332,10 +332,10 @@ def fixup_project_settings(
     Called automatically by :func:`pack_gcode_3mf`. Also useful standalone
     for patching existing 3MF archives.
     """
-    result = dict(settings)
+    result = {k: (list(v) if isinstance(v, list) else v) for k, v in settings.items()}
     for key, default in _BC_REQUIRED_KEYS.items():
         if key not in result:
-            result[key] = default
+            result[key] = list(default) if isinstance(default, list) else default
     for key, val in result.items():
         if isinstance(val, list) and 0 < len(val) < min_slots:
             while len(val) < min_slots:

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -422,6 +422,30 @@ class TestHelpers:
         assert padded["filament_type"] == ["PLA", "PETG", "PETG", "PETG", "PETG"]
         assert padded["speed"] == "100"
 
+    def test_fixup_does_not_mutate_caller_dict(self) -> None:
+        original_list = ["PLA", "PETG"]
+        settings: dict[str, object] = {
+            "filament_type": original_list,
+            "speed": "100",
+        }
+        fixup_project_settings(settings)
+        assert original_list == ["PLA", "PETG"], "caller's list was mutated"
+        assert settings["filament_type"] == ["PLA", "PETG"], "caller's dict was mutated"
+
+    def test_fixup_does_not_mutate_bc_required_keys(self) -> None:
+        from bambox.pack import _BC_REQUIRED_KEYS
+
+        snapshots = {k: list(v) if isinstance(v, list) else v for k, v in _BC_REQUIRED_KEYS.items()}
+        fixup_project_settings({})
+        fixup_project_settings({})  # second call to detect accumulated mutation
+        for k, v in _BC_REQUIRED_KEYS.items():
+            assert v == snapshots[k], f"_BC_REQUIRED_KEYS[{k!r}] was mutated"
+
+    def test_fixup_returns_padded_arrays(self) -> None:
+        settings: dict[str, object] = {"filament_colour": ["#FF0000"]}
+        result = fixup_project_settings(settings, min_slots=5)
+        assert result["filament_colour"] == ["#FF0000"] * 5
+
 
 # ---------------------------------------------------------------------------
 # File output


### PR DESCRIPTION
## Summary
- `fixup_project_settings()` used a shallow `dict()` copy, so the padding loop mutated caller-owned list objects and shared `_BC_REQUIRED_KEYS` defaults
- Replace with a dict comprehension that copies list values via `list(v)`, and copy defaults from `_BC_REQUIRED_KEYS` before inserting them
- Add three targeted tests: caller dict not mutated, `_BC_REQUIRED_KEYS` not mutated across calls, returned arrays properly padded

## Test plan
- [x] `uv run ruff check src tests` — passes
- [x] `uv run ruff format --check src tests` — passes
- [x] `uv run mypy src/bambox` — passes
- [x] `uv run pytest tests/test_pack.py` — 37/37 pass (3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)