### PR TITLE
Handle XML namespaces in AMS mapping and color patching

### DIFF
--- a/changes/+fix-xml-namespace.bugfix
+++ b/changes/+fix-xml-namespace.bugfix
@@ -1,0 +1,1 @@
+AMS mapping and color patching now handle XML namespaces in slice_info.config.

--- a/src/bambox/bridge.py
+++ b/src/bambox/bridge.py
@@ -22,6 +22,15 @@ from pathlib import Path
 
 log = logging.getLogger(__name__)
 
+
+def _xml_ns(root: ET.Element) -> str:
+    """Return the default namespace prefix (e.g. '{http://...}') or empty string."""
+    tag = root.tag
+    if tag.startswith("{"):
+        return tag[: tag.index("}") + 1]
+    return ""
+
+
 DOCKER_IMAGE = "estampo/cloud-bridge:bambu-02.05.00.00"
 
 # ---------------------------------------------------------------------------
@@ -291,9 +300,10 @@ def _build_ams_mapping(
             filament_by_id: dict[int, ET.Element] = {}
             if "Metadata/slice_info.config" in z.namelist():
                 root = ET.fromstring(z.read("Metadata/slice_info.config"))
-                plate_el = root.find("plate")
+                ns = _xml_ns(root)
+                plate_el = root.find(f"{ns}plate")
                 if plate_el is not None:
-                    for f in plate_el.findall("filament"):
+                    for f in plate_el.findall(f"{ns}filament"):
                         fid = int(f.get("id", "1"))
                         filament_by_id[fid] = f
                     if not total_slots and filament_by_id:
@@ -382,12 +392,13 @@ def _patch_config_3mf_colors(
         return config_bytes
 
     root = ET.fromstring(file_data["Metadata/slice_info.config"])
-    plate_el = root.find("plate")
+    ns = _xml_ns(root)
+    plate_el = root.find(f"{ns}plate")
     if plate_el is None:
         return config_bytes
 
     changed = False
-    for f in plate_el.findall("filament"):
+    for f in plate_el.findall(f"{ns}filament"):
         fid = int(f.get("id", "1"))
         idx = fid - 1
         if idx < len(mapping):

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -2,14 +2,21 @@
 
 from __future__ import annotations
 
+import io
 import json
 import subprocess
+import xml.etree.ElementTree as ET
 import zipfile
 from unittest.mock import patch
 
 import pytest
 
-from bambox.bridge import _build_ams_mapping, _find_local_bridge, _run_bridge_local
+from bambox.bridge import (
+    _build_ams_mapping,
+    _find_local_bridge,
+    _patch_config_3mf_colors,
+    _run_bridge_local,
+)
 
 
 class TestFindLocalBridge:
@@ -167,3 +174,125 @@ class TestBuildAmsMapping:
 
         with pytest.raises(RuntimeError, match="Filament slot 2.*no matching AMS tray"):
             _build_ams_mapping(threemf, ams_trays)
+
+
+def _make_namespaced_3mf(path, filaments, namespace, project_settings=None):
+    """Create a minimal 3MF with a namespaced slice_info.config."""
+    slice_info = f'<config xmlns="{namespace}">\n  <plate>\n'
+    for fid, ftype, color in filaments:
+        slice_info += f'    <filament id="{fid}" type="{ftype}" color="#{color}" />\n'
+    slice_info += "  </plate>\n</config>"
+
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("Metadata/slice_info.config", slice_info)
+        if project_settings is not None:
+            z.writestr(
+                "Metadata/project_settings.config",
+                json.dumps(project_settings),
+            )
+
+
+class TestBuildAmsMappingNamespaced:
+    """Verify _build_ams_mapping handles XML with a default namespace."""
+
+    def test_namespaced_xml_maps_correctly(self, tmp_path):
+        threemf = tmp_path / "ns.3mf"
+        _make_namespaced_3mf(
+            threemf,
+            [(1, "PLA", "FF0000")],
+            namespace="http://example.com/bambu",
+        )
+
+        ams_trays = [
+            {
+                "phys_slot": 2,
+                "ams_id": 0,
+                "slot_id": 2,
+                "type": "PLA",
+                "color": "FF0000",
+                "tray_info_idx": "",
+            },
+        ]
+
+        result = _build_ams_mapping(threemf, ams_trays)
+        assert result["amsMapping"] == [2]
+        assert result["amsMapping2"] == [{"ams_id": 0, "slot_id": 2}]
+
+    def test_namespaced_xml_unmatched_raises(self, tmp_path):
+        threemf = tmp_path / "ns.3mf"
+        _make_namespaced_3mf(
+            threemf,
+            [(1, "PLA", "FF0000")],
+            namespace="http://example.com/bambu",
+        )
+
+        ams_trays = [
+            {
+                "phys_slot": 0,
+                "ams_id": 0,
+                "slot_id": 0,
+                "type": "PETG",
+                "color": "00FF00",
+                "tray_info_idx": "",
+            },
+        ]
+
+        with pytest.raises(RuntimeError, match="Filament slot 1.*no matching AMS tray"):
+            _build_ams_mapping(threemf, ams_trays)
+
+
+class TestPatchConfigColors:
+    """Verify _patch_config_3mf_colors handles namespaced XML."""
+
+    def _make_config_bytes(self, filaments, namespace=None):
+        """Build a config-only 3MF in memory."""
+        if namespace:
+            xml = f'<config xmlns="{namespace}">\n  <plate>\n'
+        else:
+            xml = "<config>\n  <plate>\n"
+        for fid, ftype, color in filaments:
+            xml += f'    <filament id="{fid}" type="{ftype}" color="#{color}" />\n'
+        xml += "  </plate>\n</config>"
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as z:
+            z.writestr("Metadata/slice_info.config", xml)
+        return buf.getvalue()
+
+    def test_patches_colors_no_namespace(self, tmp_path):
+        config = self._make_config_bytes([(1, "PLA", "FF0000")])
+        ams_trays = [
+            {"phys_slot": 0, "ams_id": 0, "slot_id": 0, "type": "PLA", "color": "00FF00"},
+        ]
+        mapping = [0]
+        source = tmp_path / "dummy.3mf"
+        source.touch()
+
+        patched = _patch_config_3mf_colors(config, source, ams_trays, mapping)
+        with zipfile.ZipFile(io.BytesIO(patched), "r") as z:
+            root = ET.fromstring(z.read("Metadata/slice_info.config"))
+            ns = ""
+            if root.tag.startswith("{"):
+                ns = root.tag[: root.tag.index("}") + 1]
+            fil = root.find(f"{ns}plate").find(f"{ns}filament")
+            assert fil.get("color") == "#00FF00"
+
+    def test_patches_colors_with_namespace(self, tmp_path):
+        config = self._make_config_bytes(
+            [(1, "PLA", "FF0000")], namespace="http://example.com/bambu"
+        )
+        ams_trays = [
+            {"phys_slot": 0, "ams_id": 0, "slot_id": 0, "type": "PLA", "color": "00FF00"},
+        ]
+        mapping = [0]
+        source = tmp_path / "dummy.3mf"
+        source.touch()
+
+        patched = _patch_config_3mf_colors(config, source, ams_trays, mapping)
+        with zipfile.ZipFile(io.BytesIO(patched), "r") as z:
+            root = ET.fromstring(z.read("Metadata/slice_info.config"))
+            ns = ""
+            if root.tag.startswith("{"):
+                ns = root.tag[: root.tag.index("}") + 1]
+            fil = root.find(f"{ns}plate").find(f"{ns}filament")
+            assert fil.get("color") == "#00FF00"


### PR DESCRIPTION
## Summary
- Extract `_xml_ns()` helper to detect default XML namespace prefixes in ElementTree roots
- Apply namespace-qualified `find()`/`findall()` calls in both `_build_ams_mapping()` and `_patch_config_3mf_colors()` so they work when `slice_info.config` has a default namespace (e.g. from BambuStudio/OrcaSlicer)
- Add tests for namespaced XML in both AMS mapping and color patching paths

## Test plan
- [x] `TestBuildAmsMappingNamespaced::test_namespaced_xml_maps_correctly` — verifies mapping works with xmlns
- [x] `TestBuildAmsMappingNamespaced::test_namespaced_xml_unmatched_raises` — verifies error on unmatched with xmlns
- [x] `TestPatchConfigColors::test_patches_colors_no_namespace` — verifies non-namespaced still works
- [x] `TestPatchConfigColors::test_patches_colors_with_namespace` — verifies color patching with xmlns
- [x] All existing bridge tests still pass (14/14)
- [x] ruff check, ruff format, mypy all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)