### PR TITLE
Add tests for thumbnail, assemble, bridge Docker; set up API docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,39 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - run: uv sync --extra docs --extra dev
+      - run: uv run pdoc -o _site bambox
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/changes/+api-docs.feature
+++ b/changes/+api-docs.feature
@@ -1,0 +1,1 @@
+Add API documentation site via pdoc, deployed to GitHub Pages.

--- a/changes/+tests-assemble.misc
+++ b/changes/+tests-assemble.misc
@@ -1,0 +1,1 @@
+Add 10 dedicated tests for assemble.py (component ordering, empty inputs).

--- a/changes/+tests-bridge-docker.misc
+++ b/changes/+tests-bridge-docker.misc
@@ -1,0 +1,1 @@
+Add 12 tests for bridge.py Docker invocation paths (bind-mount, baked fallback, error handling).

--- a/changes/+tests-thumbnail.misc
+++ b/changes/+tests-thumbnail.misc
@@ -1,0 +1,1 @@
+Add 20 dedicated tests for thumbnail.py (PNG rendering, bounding box, edge cases).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ dev = [
     "pillow>=10.0.0",
     "towncrier>=24.7.0",
 ]
+docs = [
+    "pdoc>=14.0.0",
+]
 
 [project.scripts]
 bambox = "bambox.cli:main"

--- a/tests/test_assemble.py
+++ b/tests/test_assemble.py
@@ -1,0 +1,86 @@
+"""Tests for assemble.py — G-code component assembly."""
+
+from __future__ import annotations
+
+from bambox.assemble import assemble_gcode
+
+
+class TestAssembleGcode:
+    def test_basic_assembly(self):
+        """Start + toolpath + end joined with newlines."""
+        result = assemble_gcode("G28", "G1 X10 Y10 E0.5", "M84")
+        assert result == "G28\nG1 X10 Y10 E0.5\nM84\n"
+
+    def test_trailing_newlines_stripped(self):
+        """Trailing newlines on each component should be stripped."""
+        result = assemble_gcode("G28\n\n", "G1 X10\n", "M84\n\n\n")
+        assert result == "G28\nG1 X10\nM84\n"
+
+    def test_filament_start_inserted(self):
+        """Filament start G-code appears between start and toolpath."""
+        result = assemble_gcode("G28", "G1 X10 E0.5", "M84", filament_start_gcode="M104 S200")
+        lines = result.splitlines()
+        assert lines[0] == "G28"
+        assert "; filament start gcode" in lines
+        fil_idx = lines.index("; filament start gcode")
+        assert lines[fil_idx + 1] == "M104 S200"
+        # Toolpath comes after filament start
+        assert lines.index("G1 X10 E0.5") > fil_idx
+
+    def test_filament_end_inserted(self):
+        """Filament end G-code appears between toolpath and end."""
+        result = assemble_gcode("G28", "G1 X10 E0.5", "M84", filament_end_gcode="M104 S0")
+        lines = result.splitlines()
+        assert "; filament end gcode" in lines
+        fil_idx = lines.index("; filament end gcode")
+        assert lines[fil_idx + 1] == "M104 S0"
+        # End comes after filament end
+        assert lines.index("M84") > fil_idx
+
+    def test_both_filament_sections(self):
+        """Both filament start and end should be in correct positions."""
+        result = assemble_gcode(
+            "G28",
+            "G1 X10 E0.5",
+            "M84",
+            filament_start_gcode="M104 S200",
+            filament_end_gcode="M104 S0",
+        )
+        lines = result.splitlines()
+        start_idx = lines.index("; filament start gcode")
+        end_idx = lines.index("; filament end gcode")
+        toolpath_idx = lines.index("G1 X10 E0.5")
+        assert start_idx < toolpath_idx < end_idx
+
+    def test_empty_components_omitted(self):
+        """Empty strings should be omitted entirely."""
+        result = assemble_gcode("", "G1 X10 E0.5", "")
+        assert result == "G1 X10 E0.5\n"
+
+    def test_all_empty(self):
+        """All empty components should produce just a newline."""
+        result = assemble_gcode("", "", "")
+        assert result == "\n"
+
+    def test_empty_filament_gcode_omitted(self):
+        """Empty filament start/end should not insert comment markers."""
+        result = assemble_gcode("G28", "G1 X10", "M84")
+        assert "; filament start gcode" not in result
+        assert "; filament end gcode" not in result
+
+    def test_multiline_components(self):
+        """Multi-line start/toolpath/end should work correctly."""
+        start = "G28\nG29\nM104 S200"
+        toolpath = "G1 X10 E0.5\nG1 X20 E0.5\nG1 X30 E0.5"
+        end = "M104 S0\nM84"
+        result = assemble_gcode(start, toolpath, end)
+        lines = result.splitlines()
+        assert lines[0] == "G28"
+        assert lines[-1] == "M84"
+        assert len(lines) == 8
+
+    def test_result_ends_with_newline(self):
+        """Output must always end with exactly one newline."""
+        result = assemble_gcode("G28", "G1 X10", "M84")
+        assert result.endswith("\n")
+        assert not result.endswith("\n\n")

--- a/tests/test_bridge_docker.py
+++ b/tests/test_bridge_docker.py
@@ -1,0 +1,236 @@
+"""Tests for bridge.py — Docker invocation paths (bind-mount and baked fallback)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from bambox.bridge import (
+    DOCKER_IMAGE,
+    _run_bridge_baked,
+    _run_bridge_docker,
+)
+
+# -- _run_bridge_docker --------------------------------------------------------
+
+
+class TestRunBridgeDocker:
+    def test_docker_not_installed(self):
+        """FileNotFoundError from 'docker info' should raise with install hint."""
+        with patch("bambox.bridge.subprocess.run", side_effect=FileNotFoundError):
+            with pytest.raises(RuntimeError, match="Docker is not installed"):
+                _run_bridge_docker(["status", "DEV1", "/tmp/token.json"])
+
+    def test_docker_not_running(self):
+        """Non-zero 'docker info' should raise with install hint."""
+        with patch("bambox.bridge.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess([], 1, "", "error")
+            with pytest.raises(RuntimeError, match="Docker is not running"):
+                _run_bridge_docker(["status", "DEV1", "/tmp/token.json"])
+
+    def test_bind_mount_basic_args(self):
+        """Non-file args should be passed through without -v mounts."""
+        with patch("bambox.bridge.subprocess.run") as mock_run:
+            # First call = docker info (succeeds), second = docker run
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, "", ""),
+                subprocess.CompletedProcess([], 0, '{"result":"ok"}', ""),
+            ]
+            result = _run_bridge_docker(["status", "DEV1", "/tmp/token.json"])
+
+            docker_run_call = mock_run.call_args_list[1]
+            cmd = docker_run_call[0][0]
+            assert cmd[0] == "docker"
+            assert cmd[1] == "run"
+            assert "--rm" in cmd
+            assert "--platform" in cmd
+            assert DOCKER_IMAGE in cmd
+            assert "status" in cmd
+            assert "DEV1" in cmd
+            assert result.returncode == 0
+
+    def test_bind_mount_file_args(self, tmp_path):
+        """Existing file paths should be volume-mounted."""
+        test_file = tmp_path / "test.3mf"
+        test_file.write_text("fake 3mf")
+
+        with patch("bambox.bridge.subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, "", ""),
+                subprocess.CompletedProcess([], 0, '{"result":"ok"}', ""),
+            ]
+            _run_bridge_docker(["print", str(test_file), "DEV1"])
+
+            docker_run_call = mock_run.call_args_list[1]
+            cmd = docker_run_call[0][0]
+            # Should have a -v flag for the file
+            assert "-v" in cmd
+            v_idx = cmd.index("-v")
+            mount = cmd[v_idx + 1]
+            assert ":ro" in mount
+            assert "/input/test.3mf" in mount
+
+    def test_verbose_flag_appended(self):
+        """verbose=True should add -v to Docker run command."""
+        with patch("bambox.bridge.subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, "", ""),
+                subprocess.CompletedProcess([], 0, '{"result":"ok"}', ""),
+            ]
+            _run_bridge_docker(["status", "DEV1"], verbose=True)
+
+            cmd = mock_run.call_args_list[1][0][0]
+            # -v should appear after the image name (as bridge arg, not docker arg)
+            image_idx = cmd.index(DOCKER_IMAGE)
+            tail = cmd[image_idx + 1 :]
+            assert "-v" in tail
+
+    def test_bind_mount_failure_triggers_baked_fallback(self, tmp_path):
+        """'cannot read' in stderr should trigger baked fallback."""
+        test_file = tmp_path / "test.3mf"
+        test_file.write_text("fake 3mf")
+
+        with (
+            patch("bambox.bridge.subprocess.run") as mock_run,
+            patch("bambox.bridge._run_bridge_baked") as mock_baked,
+        ):
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, "", ""),  # docker info
+                subprocess.CompletedProcess([], 1, "", "cannot read /input/test.3mf"),
+            ]
+            mock_baked.return_value = subprocess.CompletedProcess([], 0, '{"result":"ok"}', "")
+
+            _run_bridge_docker(["print", str(test_file), "DEV1"])
+            mock_baked.assert_called_once()
+
+    def test_non_read_error_returns_without_fallback(self, tmp_path):
+        """Errors that aren't 'cannot read' should NOT trigger baked fallback."""
+        test_file = tmp_path / "test.3mf"
+        test_file.write_text("fake 3mf")
+
+        with (
+            patch("bambox.bridge.subprocess.run") as mock_run,
+            patch("bambox.bridge._run_bridge_baked") as mock_baked,
+        ):
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, "", ""),  # docker info
+                subprocess.CompletedProcess([], 1, "", "some other error"),
+            ]
+            result = _run_bridge_docker(["print", str(test_file), "DEV1"])
+            mock_baked.assert_not_called()
+            assert result.returncode == 1
+
+    def test_no_file_args_skips_fallback(self):
+        """Failure without file args should NOT attempt baked fallback."""
+        with (
+            patch("bambox.bridge.subprocess.run") as mock_run,
+            patch("bambox.bridge._run_bridge_baked") as mock_baked,
+        ):
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, "", ""),
+                subprocess.CompletedProcess([], 1, "", "cannot read something"),
+            ]
+            result = _run_bridge_docker(["status", "DEV1"])
+            mock_baked.assert_not_called()
+            assert result.returncode == 1
+
+
+# -- _run_bridge_baked ---------------------------------------------------------
+
+
+class TestRunBridgeBaked:
+    def test_builds_and_runs_temp_image(self, tmp_path):
+        """Should build a temp Docker image, run it, then clean up."""
+        test_file = tmp_path / "test.3mf"
+        test_file.write_text("fake 3mf content")
+        real_path = str(test_file.resolve())
+
+        file_args = {real_path: "/input/test.3mf"}
+
+        with patch("bambox.bridge.subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, "", ""),  # docker build
+                subprocess.CompletedProcess([], 0, '{"result":"ok"}', ""),  # docker run
+                subprocess.CompletedProcess([], 0, "", ""),  # docker rmi
+            ]
+            result = _run_bridge_baked(
+                ["print", str(test_file), "DEV1"],
+                file_args,
+            )
+
+            assert result.returncode == 0
+            # Verify docker build was called
+            build_call = mock_run.call_args_list[0]
+            build_cmd = build_call[0][0]
+            assert build_cmd[:3] == ["docker", "build", "-t"]
+
+            # Verify docker run was called
+            run_call = mock_run.call_args_list[1]
+            run_cmd = run_call[0][0]
+            assert run_cmd[0:2] == ["docker", "run"]
+            assert "/input/test.3mf" in run_cmd
+
+            # Verify cleanup (docker rmi)
+            rmi_call = mock_run.call_args_list[2]
+            assert "rmi" in rmi_call[0][0]
+
+    def test_build_failure_raises(self, tmp_path):
+        """Failed docker build should raise RuntimeError."""
+        test_file = tmp_path / "test.3mf"
+        test_file.write_text("fake")
+        real_path = str(test_file.resolve())
+        file_args = {real_path: "/input/test.3mf"}
+
+        with patch("bambox.bridge.subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 1, "", "build error here"),  # docker build fails
+                subprocess.CompletedProcess([], 0, "", ""),  # docker rmi cleanup
+            ]
+            with pytest.raises(RuntimeError, match="Docker build failed"):
+                _run_bridge_baked(["print", str(test_file)], file_args)
+
+    def test_verbose_flag(self, tmp_path):
+        """verbose=True should add -v to the run command."""
+        test_file = tmp_path / "test.3mf"
+        test_file.write_text("fake")
+        real_path = str(test_file.resolve())
+        file_args = {real_path: "/input/test.3mf"}
+
+        with patch("bambox.bridge.subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, "", ""),  # build
+                subprocess.CompletedProcess([], 0, '{"result":"ok"}', ""),  # run
+                subprocess.CompletedProcess([], 0, "", ""),  # rmi
+            ]
+            _run_bridge_baked(["print", str(test_file)], file_args, verbose=True)
+
+            run_cmd = mock_run.call_args_list[1][0][0]
+            assert run_cmd[-1] == "-v"
+
+    def test_dockerfile_contents(self, tmp_path):
+        """Generated Dockerfile should COPY files from base image."""
+        test_file = tmp_path / "test.3mf"
+        test_file.write_text("fake")
+        real_path = str(test_file.resolve())
+        file_args = {real_path: "/input/test.3mf"}
+
+        dockerfiles_written: list[str] = []
+
+        def capture_dockerfile(cmd, **kwargs):
+            cwd = kwargs.get("cwd", "")
+            if cwd and cmd[:2] == ["docker", "build"]:
+                df = Path(cwd) / "Dockerfile"
+                if df.exists():
+                    dockerfiles_written.append(df.read_text())
+            return subprocess.CompletedProcess([], 0, "", "")
+
+        with patch("bambox.bridge.subprocess.run", side_effect=capture_dockerfile):
+            _run_bridge_baked(["print", str(test_file)], file_args)
+
+        assert len(dockerfiles_written) == 1
+        df = dockerfiles_written[0]
+        assert df.startswith(f"FROM {DOCKER_IMAGE}")
+        assert "COPY test.3mf /input/test.3mf" in df

--- a/tests/test_thumbnail.py
+++ b/tests/test_thumbnail.py
@@ -1,0 +1,204 @@
+"""Tests for thumbnail.py — G-code to PNG rendering."""
+
+from __future__ import annotations
+
+import io
+
+from PIL import Image
+
+from bambox.thumbnail import _placeholder, gcode_thumbnail
+
+# -- Helpers ------------------------------------------------------------------
+
+SIMPLE_GCODE = """\
+; Z_HEIGHT: 0.2
+G1 X10 Y10 E0.5
+G1 X20 Y10 E0.5
+G1 X20 Y20 E0.5
+G1 X10 Y20 E0.5
+G1 X10 Y10 E0.5
+"""
+
+MULTI_LAYER_GCODE = """\
+; Z_HEIGHT: 0.2
+G1 X10 Y10 E0.5
+G1 X50 Y10 E0.5
+G1 X50 Y50 E0.5
+G1 X10 Y50 E0.5
+; Z_HEIGHT: 0.4
+G1 X10 Y10 E0.5
+G1 X50 Y10 E0.5
+G1 X50 Y50 E0.5
+"""
+
+
+def _open_png(data: bytes) -> Image.Image:
+    return Image.open(io.BytesIO(data))
+
+
+# -- gcode_thumbnail ----------------------------------------------------------
+
+
+class TestGcodeThumbnail:
+    def test_returns_valid_png(self):
+        """Output must be a valid PNG image."""
+        result = gcode_thumbnail(SIMPLE_GCODE)
+        img = _open_png(result)
+        assert img.format == "PNG"
+
+    def test_default_dimensions(self):
+        """Default output is 256x256."""
+        img = _open_png(gcode_thumbnail(SIMPLE_GCODE))
+        assert img.size == (256, 256)
+
+    def test_custom_dimensions(self):
+        """Custom width/height are respected."""
+        img = _open_png(gcode_thumbnail(SIMPLE_GCODE, width=128, height=64))
+        assert img.size == (128, 64)
+
+    def test_accepts_bytes_input(self):
+        """bytes G-code should work identically to str."""
+        result = gcode_thumbnail(SIMPLE_GCODE.encode())
+        img = _open_png(result)
+        assert img.size == (256, 256)
+
+    def test_empty_gcode_returns_placeholder(self):
+        """Empty input should produce a placeholder image, not crash."""
+        result = gcode_thumbnail("")
+        img = _open_png(result)
+        assert img.size == (256, 256)
+
+    def test_no_extrusion_returns_placeholder(self):
+        """Moves without E parameter are travel moves — no toolpath to render."""
+        gcode = """\
+; Z_HEIGHT: 0.2
+G1 X10 Y10 F3000
+G1 X20 Y20 F3000
+"""
+        result = gcode_thumbnail(gcode)
+        # Should be same as placeholder (no extrusion moves parsed)
+        placeholder = _placeholder(256, 256)
+        assert result == placeholder
+
+    def test_negative_extrusion_not_rendered(self):
+        """Retraction moves (negative E) should not produce toolpath lines."""
+        gcode = """\
+; Z_HEIGHT: 0.2
+G1 X10 Y10 E-0.8
+G1 X20 Y20 E-0.8
+"""
+        result = gcode_thumbnail(gcode)
+        assert result == _placeholder(256, 256)
+
+    def test_startup_gcode_skipped(self):
+        """G-code before the first Z_HEIGHT marker should be ignored."""
+        gcode = """\
+G28
+G1 X50 Y50 E5.0
+M104 S200
+; Z_HEIGHT: 0.2
+G1 X10 Y10 E0.5
+G1 X20 Y10 E0.5
+"""
+        result = gcode_thumbnail(gcode)
+        # Should render — there's extrusion after Z_HEIGHT
+        assert result != _placeholder(256, 256)
+
+    def test_no_z_height_marker(self):
+        """If no Z_HEIGHT marker exists, all G-code is parsed."""
+        gcode = """\
+G1 X10 Y10 E0.5
+G1 X20 Y10 E0.5
+G1 X20 Y20 E0.5
+"""
+        result = gcode_thumbnail(gcode)
+        # Should still render extrusion moves
+        assert result != _placeholder(256, 256)
+
+    def test_multi_layer_renders(self):
+        """Multi-layer G-code should produce a valid image."""
+        result = gcode_thumbnail(MULTI_LAYER_GCODE)
+        img = _open_png(result)
+        assert img.size == (256, 256)
+        assert result != _placeholder(256, 256)
+
+    def test_extrude_color_present(self):
+        """Rendered image should contain the teal extrusion color."""
+        result = gcode_thumbnail(SIMPLE_GCODE)
+        img = _open_png(result)
+        raw = img.tobytes()
+        found = any(
+            raw[i] == 0 and raw[i + 1] == 180 and raw[i + 2] == 160
+            for i in range(0, len(raw) - 2, 3)
+        )
+        assert found, "Extrusion color (teal) not found in rendered image"
+
+    def test_background_color(self):
+        """Background should be dark (25, 25, 30)."""
+        result = gcode_thumbnail(SIMPLE_GCODE)
+        img = _open_png(result)
+        bg = (25, 25, 30)
+        # Corner pixel should be background
+        assert img.getpixel((0, 0)) == bg
+
+    def test_case_insensitive_gcode(self):
+        """G-code commands should be parsed case-insensitively."""
+        gcode = """\
+; Z_HEIGHT: 0.2
+g1 x10 y10 e0.5
+g1 x20 y10 e0.5
+"""
+        result = gcode_thumbnail(gcode)
+        assert result != _placeholder(256, 256)
+
+    def test_g0_moves_with_extrusion(self):
+        """G0 rapid moves with E should also be rendered."""
+        gcode = """\
+; Z_HEIGHT: 0.2
+G0 X10 Y10 E0.5
+G0 X20 Y10 E0.5
+"""
+        result = gcode_thumbnail(gcode)
+        assert result != _placeholder(256, 256)
+
+    def test_single_point_no_crash(self):
+        """A single extrusion move from origin should not crash."""
+        gcode = """\
+; Z_HEIGHT: 0.2
+G1 X10 Y10 E0.5
+"""
+        result = gcode_thumbnail(gcode)
+        img = _open_png(result)
+        assert img.size == (256, 256)
+
+
+# -- _placeholder --------------------------------------------------------------
+
+
+class TestPlaceholder:
+    def test_returns_valid_png(self):
+        result = _placeholder()
+        img = _open_png(result)
+        assert img.format == "PNG"
+
+    def test_default_dimensions(self):
+        img = _open_png(_placeholder())
+        assert img.size == (256, 256)
+
+    def test_custom_dimensions(self):
+        img = _open_png(_placeholder(128, 64))
+        assert img.size == (128, 64)
+
+    def test_background_color(self):
+        img = _open_png(_placeholder())
+        assert img.getpixel((0, 0)) == (25, 25, 30)
+
+    def test_accent_border_present(self):
+        """The bed rectangle outline should use the accent color."""
+        img = _open_png(_placeholder())
+        raw = img.tobytes()
+        found = any(
+            raw[i] == 0 and raw[i + 1] == 150 and raw[i + 2] == 136
+            for i in range(0, len(raw) - 2, 3)
+        )
+        assert found, "Accent border color not found in placeholder"


### PR DESCRIPTION
## Summary
- **test_thumbnail.py** (20 tests): PNG rendering, bounding box calculation, edge cases (empty input, no extrusion, bytes input, case-insensitive G-code)
- **test_assemble.py** (10 tests): Component ordering, filament start/end insertion, empty inputs, trailing newline handling
- **test_bridge_docker.py** (12 tests): Docker not installed/running errors, bind-mount volume mapping, verbose flag, baked fallback trigger, Dockerfile generation
- **API docs**: pdoc workflow deploying to GitHub Pages, `docs` optional dependency group in pyproject.toml

Total: 42 new tests, bringing the suite from 321 → 363.

Closes #84, closes #85, closes #86, closes #87

## Test plan
- [x] `uv run ruff check src tests` — zero errors
- [x] `uv run ruff format --check src tests` — all formatted
- [x] `uv run mypy src/bambox` — zero errors
- [x] `uv run pytest` — 363 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)