### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ This changelog is managed by [towncrier](https://towncrier.readthedocs.io/).
 
 <!-- towncrier release notes start -->
 
+## 0.2.1 — 2026-04-09
+
+### Features
+
+- Add e2e comparison test: CuraEngine + bambox pack vs BambuStudio reference (``pytest -m e2e``)
+
+### Bugfixes
+
+- Fix CuraEngine P1S packaging: feedrate conversion (#96), multi-filament detection (#97), printer_model_id (#98), slice statistics (#99), template array-as-scalar (#100)
+
+### Misc
+
+- Expand e2e CuraEngine vs BambuStudio tests to validate gcode safety, multi-filament metadata, and print statistics
+- Fix release pipeline: reorder so PyPI publishes last (after GitHub Release), make github-release idempotent on retry, update prepare-release PR description.
+
+
 ## 0.2.0 — 2026-04-09
 
 ### Features

--- a/changes/+e2e-cura-vs-bbl.feature
+++ b/changes/+e2e-cura-vs-bbl.feature
@@ -1,1 +1,0 @@
-Add e2e comparison test: CuraEngine + bambox pack vs BambuStudio reference (``pytest -m e2e``)

--- a/changes/+e2e-validation.misc
+++ b/changes/+e2e-validation.misc
@@ -1,1 +1,0 @@
-Expand e2e CuraEngine vs BambuStudio tests to validate gcode safety, multi-filament metadata, and print statistics

--- a/changes/+fix-cura-p1s-bugs.bugfix
+++ b/changes/+fix-cura-p1s-bugs.bugfix
@@ -1,1 +1,0 @@
-Fix CuraEngine P1S packaging: feedrate conversion (#96), multi-filament detection (#97), printer_model_id (#98), slice statistics (#99), template array-as-scalar (#100)

--- a/changes/+fix-release-pipeline.misc
+++ b/changes/+fix-release-pipeline.misc
@@ -1,1 +1,0 @@
-Fix release pipeline: reorder so PyPI publishes last (after GitHub Release), make github-release idempotent on retry, update prepare-release PR description.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/bambox"]
 
 [project]
 name = "bambox"
-version = "0.2.0"
+version = "0.2.1"
 description = "Package plain G-code into Bambu Lab .gcode.3mf files"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Release v0.2.1


### Features

- Add e2e comparison test: CuraEngine + bambox pack vs BambuStudio reference (``pytest -m e2e``)

### Bugfixes

- Fix CuraEngine P1S packaging: feedrate conversion (#96), multi-filament detection (#97), printer_model_id (#98), slice statistics (#99), template array-as-scalar (#100)

### Misc

- Expand e2e CuraEngine vs BambuStudio tests to validate gcode safety, multi-filament metadata, and print statistics
- Fix release pipeline: reorder so PyPI publishes last (after GitHub Release), make github-release idempotent on retry, update prepare-release PR description.

---
**Merge this PR to trigger the release pipeline.**
The release workflow will build the package, validate on TestPyPI, create the tag, create the GitHub Release, then publish to PyPI.