### PR TITLE
Add THIRD-PARTY-NOTICES for bundled third-party IP

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -1,0 +1,71 @@
+Third-Party Notices
+====================
+
+bambox is licensed under the MIT License (see pyproject.toml).
+
+This file documents third-party components whose intellectual property
+influenced bundled data files in this repository.
+
+
+1. CuraEngine — Printer Definition Format
+------------------------------------------
+
+Files:
+  src/bambox/data/cura/bambox_p1s_ams.def.json
+  src/bambox/data/cura/bambox_p1s_ams_extruder_*.def.json
+
+The bundled CuraEngine printer definitions are original works written for
+bambox, but they use the CuraEngine definition schema (inheriting from
+"fdmprinter" and "fdmextruder" base definitions) and are intended to be
+loaded by CuraEngine at slice time.
+
+CuraEngine is developed by UltiMaker and licensed under the
+GNU Lesser General Public License v3.0 (LGPL-3.0).
+
+Source: https://github.com/Ultimaker/CuraEngine
+License: https://github.com/Ultimaker/CuraEngine/blob/main/LICENSE
+
+
+2. OrcaSlicer / BambuStudio — Profile Settings
+-----------------------------------------------
+
+Files:
+  src/bambox/profiles/base_p1s.json
+  src/bambox/profiles/filament_pla.json
+  src/bambox/profiles/filament_asa.json
+  src/bambox/profiles/filament_petg_cf.json
+  src/bambox/profiles/_varying_keys.json
+  src/bambox/profiles/_uniform_array_keys.json
+
+The profile JSON files contain printer and filament settings whose key names
+and default values are derived from OrcaSlicer and BambuStudio slicer
+profiles for Bambu Lab printers. These profiles encode the ~544 keys
+required by Bambu printer firmware in the project_settings.config archive
+entry.
+
+OrcaSlicer is a fork of BambuStudio, itself a fork of PrusaSlicer/Slic3r.
+
+OrcaSlicer is licensed under the GNU Affero General Public License v3.0
+(AGPL-3.0).
+
+Source: https://github.com/SoftFever/OrcaSlicer
+License: https://github.com/SoftFever/OrcaSlicer/blob/main/LICENSE.txt
+
+BambuStudio was originally released under the GNU Affero General Public
+License v3.0 (AGPL-3.0). Bambu Lab subsequently changed the license for
+newer releases. The profile data referenced here was derived from
+AGPL-3.0-era releases.
+
+Source: https://github.com/bambulab/BambuStudio
+License (original): AGPL-3.0
+
+
+3. Bambu Lab — Hardware Specifications
+--------------------------------------
+
+Printer dimensions, feed rates, acceleration limits, and other machine
+parameters in the above files reflect published specifications for Bambu Lab
+hardware (P1S). Factual hardware specifications are not copyrightable, but
+we acknowledge Bambu Lab as the source of these values.
+
+Website: https://bambulab.com

--- a/changes/109.misc
+++ b/changes/109.misc
@@ -1,0 +1,1 @@
+Add THIRD-PARTY-NOTICES file with license attribution for bundled CuraEngine definitions and OrcaSlicer/BambuStudio-derived profiles.


### PR DESCRIPTION
## Summary

- Adds `THIRD-PARTY-NOTICES` file documenting license attribution for bundled components:
  - **CuraEngine** (LGPL-3.0) — printer definition schema used by `src/bambox/data/cura/*.def.json`
  - **OrcaSlicer / BambuStudio** (AGPL-3.0) — profile key names and default values in `src/bambox/profiles/`
  - **Bambu Lab** — hardware specifications (factual, not copyrightable, but acknowledged)
- Adds towncrier changelog fragment

Closes #109

## Test plan
- [ ] Review attribution text for accuracy
- [ ] Verify no code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)