### PR TITLE
Fix per-filament usage tracking in CuraEngine stats

### DIFF
--- a/changes/+per-filament-usage.bugfix
+++ b/changes/+per-filament-usage.bugfix
@@ -1,0 +1,1 @@
+Populate per-filament usage (used_m/used_g) in slice_info by tracking extrusion per extruder from G-code E positions.

--- a/src/bambox/cli.py
+++ b/src/bambox/cli.py
@@ -169,6 +169,20 @@ def _cmd_pack(args: argparse.Namespace) -> None:
     # Extract print time and filament weight from slicer G-code comments
     stats = extract_slice_stats(gcode_str)
 
+    # Populate per-filament usage from stats
+    if stats.filament_used_m:
+        from bambox.cura import _PLA_DENSITY_G_PER_MM3
+        from bambox.gcode_compat import _FILAMENT_AREA
+
+        for fi in filament_infos:
+            slot_idx = fi.slot - 1  # FilamentInfo is 1-indexed
+            if slot_idx < len(stats.filament_used_m):
+                fi.used_m = stats.filament_used_m[slot_idx]
+                length_mm = stats.filament_used_m[slot_idx] * 1000
+                fi.used_g = round(
+                    length_mm * _FILAMENT_AREA * _PLA_DENSITY_G_PER_MM3, 2
+                )
+
     info = SliceInfo(
         printer_model_id=printer_model_id,
         nozzle_diameter=args.nozzle_diameter,

--- a/src/bambox/cli.py
+++ b/src/bambox/cli.py
@@ -179,9 +179,7 @@ def _cmd_pack(args: argparse.Namespace) -> None:
             if slot_idx < len(stats.filament_used_m):
                 fi.used_m = stats.filament_used_m[slot_idx]
                 length_mm = stats.filament_used_m[slot_idx] * 1000
-                fi.used_g = round(
-                    length_mm * _FILAMENT_AREA * _PLA_DENSITY_G_PER_MM3, 2
-                )
+                fi.used_g = round(length_mm * _FILAMENT_AREA * _PLA_DENSITY_G_PER_MM3, 2)
 
     info = SliceInfo(
         printer_model_id=printer_model_id,
@@ -435,12 +433,14 @@ def _show_print_info(threemf: Path) -> None:
                     except ValueError:
                         pass
                     for f in plate_el.findall(f"{ns}filament"):
-                        filaments.append((
-                            f.get("type", "?"),
-                            f.get("color", "?"),
-                            f.get("used_m", "0"),
-                            f.get("used_g", "0"),
-                        ))
+                        filaments.append(
+                            (
+                                f.get("type", "?"),
+                                f.get("color", "?"),
+                                f.get("used_m", "0"),
+                                f.get("used_g", "0"),
+                            )
+                        )
 
             # Extract layer count from G-code header
             layers = 0
@@ -486,9 +486,7 @@ def _show_print_info(threemf: Path) -> None:
     print()
 
 
-def _show_ams_mapping(
-    threemf: Path, ams_trays: list[dict], mapping: list[int]
-) -> None:
+def _show_ams_mapping(threemf: Path, ams_trays: list[dict], mapping: list[int]) -> None:
     """Display the AMS filament mapping that will be used for the print."""
     import xml.etree.ElementTree as ET
     import zipfile

--- a/src/bambox/cura.py
+++ b/src/bambox/cura.py
@@ -347,24 +347,42 @@ def extract_slice_stats(gcode: str, flush_volume_mm3: float = 280.0) -> SliceSta
         stats.weight = round(total_mm * _FILAMENT_AREA * _PLA_DENSITY_G_PER_MM3, 2)
 
     # CuraEngine CLI often reports "Filament used: 0m" as a placeholder.
-    # Compute from max absolute E position per G92-reset segment instead.
+    # Compute from max absolute E position per G92-reset segment, tracked
+    # per extruder so we can report per-filament usage.
     if stats.weight == 0.0:
         segment_max = 0.0
-        total_length = 0.0
+        per_ext: dict[int, float] = {}  # extruder -> total extrusion mm
+        current_ext = 0
         for line in gcode.splitlines():
             stripped = line.strip()
             if stripped == "G92 E0":
-                total_length += segment_max
+                per_ext[current_ext] = per_ext.get(current_ext, 0.0) + segment_max
                 segment_max = 0.0
+                continue
+            m_t = re.match(r"^T(\d+)$", stripped)
+            if m_t:
+                ext = int(m_t.group(1))
+                if ext < 255:
+                    # Flush the current segment to the current extruder before switching
+                    per_ext[current_ext] = per_ext.get(current_ext, 0.0) + segment_max
+                    segment_max = 0.0
+                    current_ext = ext
                 continue
             m_e = re.match(r"G[01]\s.*E([\d.]+)", stripped)
             if m_e:
                 e_val = float(m_e.group(1))
                 if e_val > segment_max:
                     segment_max = e_val
-        total_length += segment_max  # last segment
+        per_ext[current_ext] = per_ext.get(current_ext, 0.0) + segment_max
+        total_length = sum(per_ext.values())
         if total_length > 0:
             stats.weight = round(total_length * _FILAMENT_AREA * _PLA_DENSITY_G_PER_MM3, 2)
+            # Build per-extruder metres list
+            if per_ext:
+                max_ext = max(per_ext.keys())
+                stats.filament_used_m = [
+                    round(per_ext.get(i, 0.0) / 1000, 2) for i in range(max_ext + 1)
+                ]
 
     # Compensate for firmware-level AMS purge cycles that CuraEngine doesn't
     # know about.  Each T<n> tool change (excluding the initial extruder select


### PR DESCRIPTION
## Summary
- Track E-position extrusion per extruder (via T commands) so `slice_info.config` has correct `used_m`/`used_g` per filament instead of 0.00
- Fixes `bambox print --dry-run` showing 0.00m / 0.00g for all filaments

## Test plan
- [ ] Pack a multi-filament CuraEngine .gcode.3mf and verify per-filament usage in slice_info
- [ ] `bambox print --dry-run` shows non-zero per-filament usage
- [ ] `uv run pytest` — 483 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)