### PR TITLE
Add --version flag to CLI

### DIFF
--- a/changes/+cli-version.feature
+++ b/changes/+cli-version.feature
@@ -1,0 +1,1 @@
+Add ``bambox --version`` / ``bambox -V`` flag that reports the installed package version.

--- a/src/bambox/cli.py
+++ b/src/bambox/cli.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import logging
 import sys
+from importlib.metadata import version
 from pathlib import Path
 
 from bambox.cura import (
@@ -714,6 +715,9 @@ def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(
         prog="bambox",
         description="Package and print G-code on Bambu Lab printers",
+    )
+    parser.add_argument(
+        "-V", "--version", action="version", version=f"%(prog)s {version('bambox')}"
     )
     parser.add_argument("-v", "--verbose", action="store_true", help="Enable debug logging")
     sub = parser.add_subparsers(dest="command")


### PR DESCRIPTION
## Summary
- Adds `bambox --version` / `bambox -V` that prints the installed package version via `importlib.metadata`
- Matches whatever version is installed from PyPI or TestPyPI

## Test plan
- [x] `bambox --version` outputs `bambox 0.2.2`
- [x] ruff, mypy, pytest all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)