### PR TITLE
Add --watch mode and progress bar to bambox status

### DIFF
--- a/changes/+status-watch.feature
+++ b/changes/+status-watch.feature
@@ -1,0 +1,1 @@
+Add --watch mode, --interval flag, state color mapping, and progress bar to ``bambox status``.

--- a/src/bambox/cli.py
+++ b/src/bambox/cli.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import logging
 import sys
+import time
 from importlib.metadata import version
 from pathlib import Path
 
@@ -539,6 +540,82 @@ def _show_ams_mapping(threemf: Path, ams_trays: list[dict], mapping: list[int]) 
     print()
 
 
+_STATE_COLORS: dict[str, str] = {
+    "IDLE": "\033[2m",
+    "RUNNING": "\033[32m",
+    "PAUSE": "\033[33m",
+    "FINISH": "\033[34m",
+    "FAILED": "\033[31m",
+}
+_RESET = "\033[0m"
+
+
+def _format_progress_bar(percent: int, width: int = 24) -> str:
+    """Render a simple progress bar string from a percentage (0-100)."""
+    percent = max(0, min(100, percent))
+    filled = round(width * percent / 100)
+    empty = width - filled
+    return f"[{'█' * filled}{'░' * empty}] {percent}%"
+
+
+def _format_status(
+    status: dict,
+    ams_trays: list[dict] | None = None,
+    use_color: bool = True,
+) -> str:
+    """Format printer status dict into a human-readable string.
+
+    Parameters
+    ----------
+    status:
+        Raw status dict from the bridge (keys: gcode_state, nozzle_temper, etc.)
+    ams_trays:
+        Parsed AMS tray list, or *None* to omit AMS section.
+    use_color:
+        When *True*, apply ANSI colour escapes to the gcode_state line.
+    """
+    lines: list[str] = []
+
+    state = status.get("gcode_state", "?")
+    if use_color:
+        color = _STATE_COLORS.get(state, "")
+        reset = _RESET if color else ""
+        lines.append(f"State: {color}{state}{reset}")
+    else:
+        lines.append(f"State: {state}")
+
+    nozzle = status.get("nozzle_temper", "?")
+    bed = status.get("bed_temper", "?")
+    lines.append(f"Nozzle: {nozzle}\u00b0C  Bed: {bed}\u00b0C")
+
+    mc_percent = status.get("mc_percent")
+    if mc_percent:
+        bar = _format_progress_bar(int(mc_percent))
+        remaining = status.get("mc_remaining_time", "?")
+        if remaining != "?" and remaining is not None:
+            try:
+                mins = int(remaining)
+                hrs, m = divmod(mins, 60)
+                eta_str = f"{hrs}h {m:02d}m" if hrs else f"{m}m"
+            except (ValueError, TypeError):
+                eta_str = f"{remaining}min"
+        else:
+            eta_str = "?"
+        lines.append(f"Progress: {bar}  ETA {eta_str}")
+
+    if status.get("subtask_name"):
+        lines.append(f"Job: {status['subtask_name']}")
+
+    if ams_trays:
+        lines.append("AMS trays:")
+        for t in ams_trays:
+            lines.append(
+                f"  Slot {t['phys_slot']}: {t['type']} #{t['color']} ({t['tray_info_idx']})"
+            )
+
+    return "\n".join(lines)
+
+
 def _cmd_status(args: argparse.Namespace) -> None:
     """Query printer status."""
     from bambox.bridge import _write_token_json, load_credentials, parse_ams_trays, query_status
@@ -553,25 +630,25 @@ def _cmd_status(args: argparse.Namespace) -> None:
     credentials = load_credentials(creds_path)
     token_file = _write_token_json(credentials)
     try:
-        status = query_status(device_id, token_file, verbose=args.verbose)
-        # Show key info
-        state = status.get("gcode_state", "?")
-        nozzle = status.get("nozzle_temper", "?")
-        bed = status.get("bed_temper", "?")
-        print(f"State: {state}")
-        print(f"Nozzle: {nozzle}°C  Bed: {bed}°C")
-        if status.get("mc_percent"):
-            print(
-                f"Progress: {status['mc_percent']}%  ETA: {status.get('mc_remaining_time', '?')}min"
-            )
-        if status.get("subtask_name"):
-            print(f"Job: {status['subtask_name']}")
+        watch = getattr(args, "watch", False)
+        interval = getattr(args, "interval", 10)
 
-        trays = parse_ams_trays(status)
-        if trays:
-            print("AMS trays:")
-            for t in trays:
-                print(f"  Slot {t['phys_slot']}: {t['type']} #{t['color']} ({t['tray_info_idx']})")
+        if watch:
+            # Watch mode: clear screen and loop until Ctrl-C
+            try:
+                while True:
+                    sys.stdout.write("\033[2J\033[H")
+                    sys.stdout.flush()
+                    status = query_status(device_id, token_file, verbose=args.verbose)
+                    trays = parse_ams_trays(status)
+                    print(_format_status(status, ams_trays=trays))
+                    time.sleep(interval)
+            except KeyboardInterrupt:
+                print()  # clean line after ^C
+        else:
+            status = query_status(device_id, token_file, verbose=args.verbose)
+            trays = parse_ams_trays(status)
+            print(_format_status(status, ams_trays=trays))
     finally:
         try:
             token_file.unlink()
@@ -816,6 +893,19 @@ def main(argv: list[str] | None = None) -> None:
         "--credentials",
         default=None,
         help="Path to credentials.toml",
+    )
+    status_p.add_argument(
+        "-w",
+        "--watch",
+        action="store_true",
+        help="Continuously refresh status display",
+    )
+    status_p.add_argument(
+        "-i",
+        "--interval",
+        type=int,
+        default=10,
+        help="Seconds between refreshes in watch mode (default: 10)",
     )
 
     args = parser.parse_args(argv)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,8 @@ import pytest
 
 from bambox.cli import (
     _assign_filament_slots,
+    _format_progress_bar,
+    _format_status,
     _parse_filament_args,
     main,
 )
@@ -611,3 +613,176 @@ class TestMainDispatch:
         # argparse exits with code 2 for unrecognized args
         with pytest.raises(SystemExit, match="2"):
             main(["--nonexistent-flag"])
+
+
+# ---------------------------------------------------------------------------
+# _format_status / _format_progress_bar
+# ---------------------------------------------------------------------------
+
+
+class TestFormatProgressBar:
+    def test_zero_percent(self) -> None:
+        bar = _format_progress_bar(0, width=10)
+        assert bar == "[░░░░░░░░░░] 0%"
+
+    def test_hundred_percent(self) -> None:
+        bar = _format_progress_bar(100, width=10)
+        assert bar == "[██████████] 100%"
+
+    def test_fifty_percent(self) -> None:
+        bar = _format_progress_bar(50, width=10)
+        assert bar == "[█████░░░░░] 50%"
+
+    def test_clamps_above_100(self) -> None:
+        bar = _format_progress_bar(120, width=10)
+        assert bar == "[██████████] 100%"
+
+    def test_clamps_below_0(self) -> None:
+        bar = _format_progress_bar(-5, width=10)
+        assert bar == "[░░░░░░░░░░] 0%"
+
+    def test_default_width(self) -> None:
+        bar = _format_progress_bar(50)
+        # Default width=24, half filled = 12
+        assert bar.startswith("[")
+        assert "50%" in bar
+
+
+class TestFormatStatus:
+    def test_idle_no_color(self) -> None:
+        status = {"gcode_state": "IDLE", "nozzle_temper": 25, "bed_temper": 22}
+        text = _format_status(status, use_color=False)
+        assert "State: IDLE" in text
+        assert "25\u00b0C" in text
+        assert "22\u00b0C" in text
+
+    def test_running_with_color(self) -> None:
+        status = {"gcode_state": "RUNNING", "nozzle_temper": 220, "bed_temper": 60}
+        text = _format_status(status, use_color=True)
+        assert "\033[32m" in text  # green
+        assert "\033[0m" in text  # reset
+        assert "RUNNING" in text
+
+    def test_failed_color(self) -> None:
+        status = {"gcode_state": "FAILED", "nozzle_temper": 0, "bed_temper": 0}
+        text = _format_status(status, use_color=True)
+        assert "\033[31m" in text  # red
+
+    def test_pause_color(self) -> None:
+        status = {"gcode_state": "PAUSE", "nozzle_temper": 0, "bed_temper": 0}
+        text = _format_status(status, use_color=True)
+        assert "\033[33m" in text  # yellow
+
+    def test_finish_color(self) -> None:
+        status = {"gcode_state": "FINISH", "nozzle_temper": 0, "bed_temper": 0}
+        text = _format_status(status, use_color=True)
+        assert "\033[34m" in text  # blue
+
+    def test_unknown_state_no_color_escape(self) -> None:
+        status = {"gcode_state": "WEIRD", "nozzle_temper": 0, "bed_temper": 0}
+        text = _format_status(status, use_color=True)
+        assert "\033[" not in text
+        assert "WEIRD" in text
+
+    def test_progress_bar_rendered(self) -> None:
+        status = {
+            "gcode_state": "RUNNING",
+            "nozzle_temper": 220,
+            "bed_temper": 60,
+            "mc_percent": 42,
+            "mc_remaining_time": 83,
+        }
+        text = _format_status(status, use_color=False)
+        assert "42%" in text
+        assert "1h 23m" in text
+        assert "█" in text
+
+    def test_progress_no_eta(self) -> None:
+        status = {
+            "gcode_state": "RUNNING",
+            "nozzle_temper": 220,
+            "bed_temper": 60,
+            "mc_percent": 10,
+            "mc_remaining_time": None,
+        }
+        text = _format_status(status, use_color=False)
+        assert "10%" in text
+        assert "ETA ?" in text
+
+    def test_subtask_name(self) -> None:
+        status = {
+            "gcode_state": "RUNNING",
+            "nozzle_temper": 220,
+            "bed_temper": 60,
+            "subtask_name": "benchy.3mf",
+        }
+        text = _format_status(status, use_color=False)
+        assert "benchy.3mf" in text
+
+    def test_ams_trays_included(self) -> None:
+        status = {"gcode_state": "IDLE", "nozzle_temper": 25, "bed_temper": 22}
+        trays = [{"phys_slot": 0, "type": "PLA", "color": "FFFFFF", "tray_info_idx": "GFL00"}]
+        text = _format_status(status, ams_trays=trays, use_color=False)
+        assert "AMS trays" in text
+        assert "PLA" in text
+
+    def test_eta_minutes_only(self) -> None:
+        status = {
+            "gcode_state": "RUNNING",
+            "nozzle_temper": 220,
+            "bed_temper": 60,
+            "mc_percent": 90,
+            "mc_remaining_time": 5,
+        }
+        text = _format_status(status, use_color=False)
+        assert "5m" in text
+        # Should NOT have hours
+        assert "0h" not in text
+
+
+class TestStatusWatchArgs:
+    """Test that --watch and --interval flags are parsed correctly."""
+
+    def test_watch_flag_parsed(self) -> None:
+        creds = {"token": "tok"}
+        status = {"gcode_state": "IDLE", "nozzle_temper": 25, "bed_temper": 22}
+        token = MagicMock()
+
+        with (
+            patch("bambox.bridge.load_credentials", return_value=creds),
+            patch("bambox.bridge._write_token_json", return_value=token),
+            patch("bambox.bridge.query_status", return_value=status),
+            patch("bambox.bridge.parse_ams_trays", return_value=[]),
+            patch("time.sleep", side_effect=KeyboardInterrupt),
+        ):
+            main(["status", "DEVICE123", "--watch"])
+        # If we get here without error, the watch loop ran and exited on KeyboardInterrupt
+
+    def test_interval_flag_parsed(self) -> None:
+        creds = {"token": "tok"}
+        status = {"gcode_state": "IDLE", "nozzle_temper": 25, "bed_temper": 22}
+        token = MagicMock()
+
+        with (
+            patch("bambox.bridge.load_credentials", return_value=creds),
+            patch("bambox.bridge._write_token_json", return_value=token),
+            patch("bambox.bridge.query_status", return_value=status),
+            patch("bambox.bridge.parse_ams_trays", return_value=[]),
+            patch("time.sleep", side_effect=KeyboardInterrupt) as mock_sleep,
+        ):
+            main(["status", "DEVICE123", "--watch", "--interval", "5"])
+        mock_sleep.assert_called_once_with(5)
+
+    def test_watch_short_flag(self) -> None:
+        creds = {"token": "tok"}
+        status = {"gcode_state": "IDLE", "nozzle_temper": 25, "bed_temper": 22}
+        token = MagicMock()
+
+        with (
+            patch("bambox.bridge.load_credentials", return_value=creds),
+            patch("bambox.bridge._write_token_json", return_value=token),
+            patch("bambox.bridge.query_status", return_value=status),
+            patch("bambox.bridge.parse_ams_trays", return_value=[]),
+            patch("time.sleep", side_effect=KeyboardInterrupt),
+        ):
+            main(["status", "DEVICE123", "-w", "-i", "3"])


### PR DESCRIPTION
## Summary
Closes #90.

- `--watch` / `-w` flag: live refresh loop with screen clear, Ctrl-C to exit
- `--interval` / `-i` flag: custom refresh interval (default 10s)
- State color mapping: IDLE→dim, RUNNING→green, PAUSE→yellow, FINISH→blue, FAILED→red
- Progress bar rendering: `[████████░░░░░░░░░░░░] 42%  ETA 1h 23m`
- Extracted `_format_status()` for testable rendering

## Test plan
- [x] 20 new tests for format_status, progress bar, arg parsing
- [x] ruff, mypy, pytest all pass (512 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)