### PR TITLE
Wire WasCancelledFn cancel flag through Rust bridge

### DIFF
--- a/bridge/shim/shim.cpp
+++ b/bridge/shim/shim.cpp
@@ -455,7 +455,8 @@ int bambu_shim_start_print(
     const BambuShimPrintParams* p,
     shim_on_print_progress_fn progress_cb,
     void* progress_ctx,
-    BambuShimPrintResult* result
+    BambuShimPrintResult* result,
+    const int* cancel_flag
 ) {
     if (!fp_start_print) return -1;
 
@@ -517,7 +518,9 @@ int bambu_shim_start_print(
         else if (status == 7) { result->print_result = code; result->finished = 1; }
     };
 
-    WasCancelledFn cancel_fn = []() -> bool { return false; };
+    WasCancelledFn cancel_fn = [cancel_flag]() -> bool {
+        return cancel_flag && __atomic_load_n(cancel_flag, __ATOMIC_ACQUIRE) != 0;
+    };
     OnWaitFn wait_fn = [](int, std::string) -> bool { return false; };
 
     result->return_code = fp_start_print(agent, params, update_fn, cancel_fn, wait_fn);

--- a/bridge/src/agent.rs
+++ b/bridge/src/agent.rs
@@ -4,9 +4,9 @@
 //! configure → login → connect → subscribe → send/receive messages.
 
 use std::ffi::CString;
-use std::os::raw::{c_char, c_void};
+use std::os::raw::{c_char, c_int, c_void};
 use std::path::Path;
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicI32, Ordering};
 use std::time::Duration;
 
 use crate::callbacks::{self, CallbackState};
@@ -179,6 +179,8 @@ pub struct BambuAgent {
     state: Box<CallbackState>,
     /// Base directory for cert/config/log files.
     data_dir: String,
+    /// Flag checked by WasCancelledFn during file upload. Set to non-zero to cancel.
+    cancel_flag: AtomicI32,
 }
 
 // The agent pointer is thread-safe (the .so manages its own locking)
@@ -243,6 +245,7 @@ impl BambuAgent {
             agent,
             state,
             data_dir,
+            cancel_flag: AtomicI32::new(0),
         };
         this.configure()?;
         Ok(this)
@@ -530,11 +533,15 @@ impl BambuAgent {
             finished: 0,
         };
 
+        // Reset cancel flag before starting
+        self.cancel_flag.store(0, Ordering::SeqCst);
+
         // Retry on enc flag not ready (-3140)
         for attempt in 0..5 {
             result.print_result = -999;
             result.finished = 0;
 
+            let cancel_ptr = &self.cancel_flag as *const AtomicI32 as *const c_int;
             let ret = unsafe {
                 ffi::bambu_shim_start_print(
                     self.agent,
@@ -542,6 +549,7 @@ impl BambuAgent {
                     print_progress_callback,
                     std::ptr::null_mut(),
                     &mut result,
+                    cancel_ptr,
                 )
             };
 
@@ -575,6 +583,16 @@ impl BambuAgent {
         })
     }
 
+    /// Cancel the current in-flight print (if any).
+    ///
+    /// Sets the atomic cancel flag that the C++ `WasCancelledFn` lambda polls
+    /// during file upload. The .so checks this flag periodically and aborts
+    /// the upload when it sees a non-zero value.
+    pub fn cancel_current_print(&self) {
+        self.cancel_flag.store(1, Ordering::SeqCst);
+        tracing::info!("cancel flag set");
+    }
+
     /// Drain all buffered MQTT messages.
     pub fn drain_messages(&self) -> Vec<callbacks::MqttMessage> {
         self.state.drain_messages()
@@ -599,6 +617,7 @@ impl BambuAgent {
             agent: std::ptr::null_mut(),
             state: Box::new(CallbackState::new()),
             data_dir: "/tmp/bambu_agent".to_string(),
+            cancel_flag: AtomicI32::new(0),
         }
     }
 
@@ -855,6 +874,19 @@ email = "user@example.com"
         let path = std::path::PathBuf::from("/tmp/nonexistent_creds_12345.toml");
         let err = Credentials::from_toml(&path).unwrap_err();
         assert!(err.contains("cannot read"));
+    }
+
+    #[test]
+    fn cancel_flag_initially_zero() {
+        let agent = unsafe { BambuAgent::test_null() };
+        assert_eq!(agent.cancel_flag.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn cancel_sets_flag() {
+        let agent = unsafe { BambuAgent::test_null() };
+        agent.cancel_current_print();
+        assert_eq!(agent.cancel_flag.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/bridge/src/ffi.rs
+++ b/bridge/src/ffi.rs
@@ -146,5 +146,6 @@ extern "C" {
         progress_cb: OnPrintProgressFn,
         progress_ctx: *mut c_void,
         result: *mut ShimPrintResult,
+        cancel_flag: *const c_int,
     ) -> c_int;
 }

--- a/bridge/src/handle.rs
+++ b/bridge/src/handle.rs
@@ -37,6 +37,9 @@ pub enum AgentCommand {
         request: PrintRequest,
         reply: oneshot::Sender<Result<PrintResult, String>>,
     },
+    CancelPrint {
+        reply: oneshot::Sender<()>,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -111,6 +114,19 @@ impl AgentHandle {
             .await
             .map_err(|_| "agent thread gone".to_string())?;
         rx.await.map_err(|_| "agent thread dropped reply".to_string())?
+    }
+
+    /// Cancel the current in-flight print upload.
+    ///
+    /// Sets the atomic cancel flag so the C++ upload loop aborts, and also
+    /// sends the MQTT stop command to the printer.
+    pub async fn cancel_print(&self) -> Result<(), String> {
+        let (reply, rx) = oneshot::channel();
+        self.tx
+            .send(AgentCommand::CancelPrint { reply })
+            .await
+            .map_err(|_| "agent thread gone".to_string())?;
+        rx.await.map_err(|_| "agent thread dropped reply".to_string())
     }
 }
 
@@ -191,6 +207,10 @@ pub fn spawn_agent_thread(agent: BambuAgent) -> AgentHandle {
                     AgentCommand::StartPrint { request, reply } => {
                         let result = agent.start_print(&request);
                         let _ = reply.send(result);
+                    }
+                    AgentCommand::CancelPrint { reply } => {
+                        agent.cancel_current_print();
+                        let _ = reply.send(());
                     }
                 }
 
@@ -338,6 +358,28 @@ mod tests {
 
         let result = handle.send_message("DEV".into(), "{}".into()).await;
         assert_eq!(result.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn cancel_print_fails_when_channel_closed() {
+        let handle = test_handle();
+        let result = handle.cancel_print().await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "agent thread gone");
+    }
+
+    #[tokio::test]
+    async fn cancel_print_succeeds_with_reply() {
+        let (handle, mut rx) = test_handle_with_receiver();
+
+        tokio::spawn(async move {
+            if let Some(AgentCommand::CancelPrint { reply }) = rx.recv().await {
+                let _ = reply.send(());
+            }
+        });
+
+        let result = handle.cancel_print().await;
+        assert!(result.is_ok());
     }
 
     #[tokio::test]

--- a/bridge/src/server.rs
+++ b/bridge/src/server.rs
@@ -289,6 +289,10 @@ async fn cancel_print(
     State(state): State<SharedState>,
     Path(device_id): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+    // Set the atomic cancel flag so any in-flight upload aborts immediately
+    let _ = state.handle.cancel_print().await;
+
+    // Also send the MQTT stop command to the printer
     let stop_cmd = r#"{"print":{"command":"stop","sequence_id":"0"}}"#;
     let ret = state
         .handle
@@ -312,6 +316,7 @@ async fn cancel_print(
         "command": "stop",
         "device_id": device_id,
         "sent": true,
+        "upload_cancelled": true,
     })))
 }
 

--- a/changes/+bridge-cancel-flag.feature
+++ b/changes/+bridge-cancel-flag.feature
@@ -1,0 +1,1 @@
+Wire WasCancelledFn through the Rust bridge so in-flight uploads can be cancelled via the /cancel endpoint


### PR DESCRIPTION
## Summary

Closes #28 — the last remaining item (WasCancelledFn wiring) for bridge production hardening.

- **shim.cpp**: `bambu_shim_start_print` now accepts a `const int* cancel_flag`; the `WasCancelledFn` lambda reads it via `__atomic_load_n`
- **ffi.rs**: FFI declaration updated with `cancel_flag: *const c_int`
- **agent.rs**: `BambuAgent` owns an `AtomicI32` cancel flag, resets it before each print, passes pointer to FFI call. New `cancel_current_print()` method sets it to 1
- **handle.rs**: New `CancelPrint` command variant and `cancel_print()` async method on `AgentHandle`
- **server.rs**: `POST /cancel/:device_id` now sets the cancel flag (aborting in-flight uploads) in addition to sending the MQTT stop command

## Test plan

- [ ] `cargo test` passes (agent cancel flag tests + handle channel tests)
- [ ] Manual: start a print via `/print`, then `POST /cancel/:device_id` — upload should abort
- [ ] Verify cancel flag resets on next print (no stale cancellation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)