### PR TITLE
Fix Docker bridge: pass --user uid:gid and pull image

### DIFF
--- a/changes/+docker-uid-pull.bugfix
+++ b/changes/+docker-uid-pull.bugfix
@@ -1,0 +1,1 @@
+Pass --user uid:gid to Docker bridge containers and pull image before each run

--- a/src/bambox/bridge.py
+++ b/src/bambox/bridge.py
@@ -185,9 +185,10 @@ def _run_bridge_docker(
     )
 
     # Collect local file paths for potential bake fallback
-    uid_gid = f"{os.getuid()}:{os.getgid()}"
     file_args: dict[str, str] = {}  # host_path -> container_path
-    cmd: list[str] = ["docker", "run", "--rm", "--platform", "linux/amd64", "--user", uid_gid]
+    cmd: list[str] = ["docker", "run", "--rm", "--platform", "linux/amd64"]
+    if hasattr(os, "getuid"):
+        cmd.extend(["--user", f"{os.getuid()}:{os.getgid()}"])
     docker_args: list[str] = []
     for arg in args:
         if os.path.exists(arg):
@@ -256,17 +257,11 @@ def _run_bridge_baked(
             else:
                 docker_args.append(arg)
 
-        uid_gid = f"{os.getuid()}:{os.getgid()}"
-        cmd = [
-            "docker",
-            "run",
-            "--rm",
-            "--platform",
-            "linux/amd64",
-            "--user",
-            uid_gid,
-            tag,
-        ] + docker_args
+        cmd = ["docker", "run", "--rm", "--platform", "linux/amd64"]
+        if hasattr(os, "getuid"):
+            cmd.extend(["--user", f"{os.getuid()}:{os.getgid()}"])
+        cmd.append(tag)
+        cmd.extend(docker_args)
         if verbose:
             cmd.append("-v")
 

--- a/src/bambox/bridge.py
+++ b/src/bambox/bridge.py
@@ -177,9 +177,17 @@ def _run_bridge_docker(
     if docker_info.returncode != 0:
         raise RuntimeError(f"bambox-bridge not found and Docker is not running.\n{install_hint}")
 
+    # Pull image if not present (or if a newer version is available)
+    subprocess.run(
+        ["docker", "pull", "--quiet", DOCKER_IMAGE],
+        capture_output=True,
+        timeout=120,
+    )
+
     # Collect local file paths for potential bake fallback
+    uid_gid = f"{os.getuid()}:{os.getgid()}"
     file_args: dict[str, str] = {}  # host_path -> container_path
-    cmd: list[str] = ["docker", "run", "--rm", "--platform", "linux/amd64"]
+    cmd: list[str] = ["docker", "run", "--rm", "--platform", "linux/amd64", "--user", uid_gid]
     docker_args: list[str] = []
     for arg in args:
         if os.path.exists(arg):
@@ -248,7 +256,17 @@ def _run_bridge_baked(
             else:
                 docker_args.append(arg)
 
-        cmd = ["docker", "run", "--rm", "--platform", "linux/amd64", tag] + docker_args
+        uid_gid = f"{os.getuid()}:{os.getgid()}"
+        cmd = [
+            "docker",
+            "run",
+            "--rm",
+            "--platform",
+            "linux/amd64",
+            "--user",
+            uid_gid,
+            tag,
+        ] + docker_args
         if verbose:
             cmd.append("-v")
 

--- a/tests/test_bridge_docker.py
+++ b/tests/test_bridge_docker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
@@ -13,6 +14,8 @@ from bambox.bridge import (
     _run_bridge_baked,
     _run_bridge_docker,
 )
+
+_HAS_GETUID = hasattr(os, "getuid")
 
 # -- _run_bridge_docker --------------------------------------------------------
 
@@ -48,7 +51,7 @@ class TestRunBridgeDocker:
             assert cmd[1] == "run"
             assert "--rm" in cmd
             assert "--platform" in cmd
-            assert "--user" in cmd
+            assert ("--user" in cmd) == _HAS_GETUID
             assert DOCKER_IMAGE in cmd
             assert "status" in cmd
             assert "DEV1" in cmd
@@ -174,11 +177,11 @@ class TestRunBridgeBaked:
             build_cmd = build_call[0][0]
             assert build_cmd[:3] == ["docker", "build", "-t"]
 
-            # Verify docker run was called with --user
+            # Verify docker run was called (with --user on Unix)
             run_call = mock_run.call_args_list[1]
             run_cmd = run_call[0][0]
             assert run_cmd[0:2] == ["docker", "run"]
-            assert "--user" in run_cmd
+            assert ("--user" in run_cmd) == _HAS_GETUID
             assert "/input/test.3mf" in run_cmd
 
             # Verify cleanup (docker rmi)

--- a/tests/test_bridge_docker.py
+++ b/tests/test_bridge_docker.py
@@ -34,19 +34,21 @@ class TestRunBridgeDocker:
     def test_bind_mount_basic_args(self):
         """Non-file args should be passed through without -v mounts."""
         with patch("bambox.bridge.subprocess.run") as mock_run:
-            # First call = docker info (succeeds), second = docker run
+            # docker info → docker pull → docker run
             mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, "", ""),
                 subprocess.CompletedProcess([], 0, "", ""),
                 subprocess.CompletedProcess([], 0, '{"result":"ok"}', ""),
             ]
             result = _run_bridge_docker(["status", "DEV1", "/tmp/token.json"])
 
-            docker_run_call = mock_run.call_args_list[1]
+            docker_run_call = mock_run.call_args_list[2]
             cmd = docker_run_call[0][0]
             assert cmd[0] == "docker"
             assert cmd[1] == "run"
             assert "--rm" in cmd
             assert "--platform" in cmd
+            assert "--user" in cmd
             assert DOCKER_IMAGE in cmd
             assert "status" in cmd
             assert "DEV1" in cmd
@@ -59,12 +61,13 @@ class TestRunBridgeDocker:
 
         with patch("bambox.bridge.subprocess.run") as mock_run:
             mock_run.side_effect = [
-                subprocess.CompletedProcess([], 0, "", ""),
-                subprocess.CompletedProcess([], 0, '{"result":"ok"}', ""),
+                subprocess.CompletedProcess([], 0, "", ""),  # docker info
+                subprocess.CompletedProcess([], 0, "", ""),  # docker pull
+                subprocess.CompletedProcess([], 0, '{"result":"ok"}', ""),  # docker run
             ]
             _run_bridge_docker(["print", str(test_file), "DEV1"])
 
-            docker_run_call = mock_run.call_args_list[1]
+            docker_run_call = mock_run.call_args_list[2]
             cmd = docker_run_call[0][0]
             # Should have a -v flag for the file
             assert "-v" in cmd
@@ -77,12 +80,13 @@ class TestRunBridgeDocker:
         """verbose=True should add -v to Docker run command."""
         with patch("bambox.bridge.subprocess.run") as mock_run:
             mock_run.side_effect = [
-                subprocess.CompletedProcess([], 0, "", ""),
-                subprocess.CompletedProcess([], 0, '{"result":"ok"}', ""),
+                subprocess.CompletedProcess([], 0, "", ""),  # docker info
+                subprocess.CompletedProcess([], 0, "", ""),  # docker pull
+                subprocess.CompletedProcess([], 0, '{"result":"ok"}', ""),  # docker run
             ]
             _run_bridge_docker(["status", "DEV1"], verbose=True)
 
-            cmd = mock_run.call_args_list[1][0][0]
+            cmd = mock_run.call_args_list[2][0][0]
             # -v should appear after the image name (as bridge arg, not docker arg)
             image_idx = cmd.index(DOCKER_IMAGE)
             tail = cmd[image_idx + 1 :]
@@ -99,6 +103,7 @@ class TestRunBridgeDocker:
         ):
             mock_run.side_effect = [
                 subprocess.CompletedProcess([], 0, "", ""),  # docker info
+                subprocess.CompletedProcess([], 0, "", ""),  # docker pull
                 subprocess.CompletedProcess([], 1, "", "cannot read /input/test.3mf"),
             ]
             mock_baked.return_value = subprocess.CompletedProcess([], 0, '{"result":"ok"}', "")
@@ -117,6 +122,7 @@ class TestRunBridgeDocker:
         ):
             mock_run.side_effect = [
                 subprocess.CompletedProcess([], 0, "", ""),  # docker info
+                subprocess.CompletedProcess([], 0, "", ""),  # docker pull
                 subprocess.CompletedProcess([], 1, "", "some other error"),
             ]
             result = _run_bridge_docker(["print", str(test_file), "DEV1"])
@@ -130,7 +136,8 @@ class TestRunBridgeDocker:
             patch("bambox.bridge._run_bridge_baked") as mock_baked,
         ):
             mock_run.side_effect = [
-                subprocess.CompletedProcess([], 0, "", ""),
+                subprocess.CompletedProcess([], 0, "", ""),  # docker info
+                subprocess.CompletedProcess([], 0, "", ""),  # docker pull
                 subprocess.CompletedProcess([], 1, "", "cannot read something"),
             ]
             result = _run_bridge_docker(["status", "DEV1"])
@@ -167,10 +174,11 @@ class TestRunBridgeBaked:
             build_cmd = build_call[0][0]
             assert build_cmd[:3] == ["docker", "build", "-t"]
 
-            # Verify docker run was called
+            # Verify docker run was called with --user
             run_call = mock_run.call_args_list[1]
             run_cmd = run_call[0][0]
             assert run_cmd[0:2] == ["docker", "run"]
+            assert "--user" in run_cmd
             assert "/input/test.3mf" in run_cmd
 
             # Verify cleanup (docker rmi)


### PR DESCRIPTION
## Summary

- **`--user uid:gid`**: Both bind-mount and baked-image `docker run` calls now pass `--user $(id -u):$(id -g)` so container-created files are owned by the host user (matches the same fix recently applied in estampo)
- **`docker pull`**: Runs `docker pull --quiet` before each Docker invocation so updated images are picked up automatically instead of using a stale local cache

## Test plan

- [x] All 26 bridge Docker tests pass (updated for new call order and `--user` assertion)
- [x] Full suite: 492 passed
- [x] `ruff check`, `ruff format`, `mypy` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)