### PR TITLE
Support pre-release versions in release workflows

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (e.g. 0.2.0)"
+        description: "Release version (e.g. 0.3.0 or 0.3.0rc1)"
         required: true
 
 jobs:
@@ -21,8 +21,8 @@ jobs:
       - name: Validate version format
         run: |
           VERSION="${{ inputs.version }}"
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Invalid version format: $VERSION (expected X.Y.Z)"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(a|b|rc)[0-9]+$ ]] && [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format: $VERSION (expected X.Y.Z or X.Y.ZrcN)"
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
 
           # Primary: parse branch name from merge commit message (instant, no API race)
           VERSION=$(echo "$MSG" \
-            | grep -oP 'release/v\K\d+\.\d+\.\d+' \
+            | grep -oP 'release/v\K\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?' \
             | head -1 || true)
 
           # Fallback: query the commits/pulls API
@@ -43,7 +43,7 @@ jobs:
               --jq '.[].head.ref')
             echo "Associated PR branches: ${BRANCHES:-<none>}"
             VERSION=$(echo "$BRANCHES" \
-              | grep -oP '^release/v\K\d+\.\d+\.\d+$' \
+              | grep -oP '^release/v\K\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?$' \
               | head -1 || true)
           fi
 
@@ -214,6 +214,10 @@ jobs:
             fi
           else
             ARGS=(gh release create "v${VERSION}" --title "v${VERSION}" --notes-file /tmp/release-body.md)
+            # Mark pre-releases (rc, alpha, beta) appropriately
+            if [[ "$VERSION" =~ (a|b|rc)[0-9]+$ ]]; then
+              ARGS+=(--prerelease)
+            fi
             if [[ -n "$WHEEL" ]]; then
               ARGS+=("$WHEEL")
             fi

--- a/changes/+prerelease-support.misc
+++ b/changes/+prerelease-support.misc
@@ -1,0 +1,1 @@
+Support pre-release versions (rc, alpha, beta) in release workflows


### PR DESCRIPTION
## Summary

- **prepare-release.yml**: Version regex now accepts `X.Y.ZrcN`, `X.Y.ZaN`, `X.Y.ZbN` in addition to `X.Y.Z`
- **release.yml**: Version detection regexes updated to match pre-release branch names (e.g. `release/v0.3.0rc1`)
- **release.yml**: GitHub Releases for pre-release versions are automatically marked with `--prerelease`

Needed for the upcoming `0.3.0rc1` release.

## Test plan

- [x] All 559 tests pass
- [ ] Trigger Prepare Release with `0.3.0rc1` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)