### PR TITLE
Release v0.3.0rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ This changelog is managed by [towncrier](https://towncrier.readthedocs.io/).
 
 <!-- towncrier release notes start -->
 
+## 0.3.0rc1 — 2026-04-10
+
+### Features
+
+- Add --watch mode, --interval flag, state color mapping, and progress bar to ``bambox status``.
+- Add ``bambox --version`` / ``bambox -V`` flag that reports the installed package version.
+- Add validation checks E013-E014 (multi-filament tool changes), W012-W014 (temperature/matrix ranges), --reference comparison mode (C001-C005), and release-readiness tests.
+- Show AMS filament slot mapping in `bambox print` output so users can verify tray assignments before printing.
+- Wire WasCancelledFn through the Rust bridge so in-flight uploads can be cancelled via the /cancel endpoint
+
+### Bugfixes
+
+- Fix "Compatible Printer" showing repeated X1 Carbon instead of P1S in Bambu Connect by moving machine-level list keys out of per-filament varying keys.
+- Fix CuraEngine bed type mapping (textured_pei_plate → Textured PEI Plate) and sync M73 remaining-time markers with purge-compensated prediction in slice_info.
+- Fix release workflow race condition: detect version from merge commit message instead of relying on GitHub API that may not be indexed yet.
+- Pass --user uid:gid to Docker bridge containers and pull image before each run
+- Populate per-filament usage (used_m/used_g) in slice_info by tracking extrusion per extruder from G-code E positions.
+
+### Misc
+
+- Improve bridge.py test coverage for credentials, AMS parsing, 3MF stripping, and cloud print. ([#80](https://github.com/estampo/bambox/pull/80))
+- Add THIRD-PARTY-NOTICES file with license attribution for bundled CuraEngine definitions and OrcaSlicer/BambuStudio-derived profiles. ([#109](https://github.com/estampo/bambox/pull/109))
+- Harden install.sh with partial-execution protection, temp file cleanup, sudo handling, and dependency checks
+- Support pre-release versions (rc, alpha, beta) in release workflows
+
+
 ## 0.2.2 — 2026-04-09
 
 ### Features

--- a/changes/+ams-mapping-display.feature
+++ b/changes/+ams-mapping-display.feature
@@ -1,1 +1,0 @@
-Show AMS filament slot mapping in `bambox print` output so users can verify tray assignments before printing.

--- a/changes/+bridge-cancel-flag.feature
+++ b/changes/+bridge-cancel-flag.feature
@@ -1,1 +1,0 @@
-Wire WasCancelledFn through the Rust bridge so in-flight uploads can be cancelled via the /cancel endpoint

--- a/changes/+cli-version.feature
+++ b/changes/+cli-version.feature
@@ -1,1 +1,0 @@
-Add ``bambox --version`` / ``bambox -V`` flag that reports the installed package version.

--- a/changes/+cura-bed-type-and-time.bugfix
+++ b/changes/+cura-bed-type-and-time.bugfix
@@ -1,1 +1,0 @@
-Fix CuraEngine bed type mapping (textured_pei_plate → Textured PEI Plate) and sync M73 remaining-time markers with purge-compensated prediction in slice_info.

--- a/changes/+docker-uid-pull.bugfix
+++ b/changes/+docker-uid-pull.bugfix
@@ -1,1 +1,0 @@
-Pass --user uid:gid to Docker bridge containers and pull image before each run

--- a/changes/+fix-compatible-printer.bugfix
+++ b/changes/+fix-compatible-printer.bugfix
@@ -1,1 +1,0 @@
-Fix "Compatible Printer" showing repeated X1 Carbon instead of P1S in Bambu Connect by moving machine-level list keys out of per-filament varying keys.

--- a/changes/+install-script-hardening.misc
+++ b/changes/+install-script-hardening.misc
@@ -1,1 +1,0 @@
-Harden install.sh with partial-execution protection, temp file cleanup, sudo handling, and dependency checks

--- a/changes/+per-filament-usage.bugfix
+++ b/changes/+per-filament-usage.bugfix
@@ -1,1 +1,0 @@
-Populate per-filament usage (used_m/used_g) in slice_info by tracking extrusion per extruder from G-code E positions.

--- a/changes/+prerelease-support.misc
+++ b/changes/+prerelease-support.misc
@@ -1,1 +1,0 @@
-Support pre-release versions (rc, alpha, beta) in release workflows

--- a/changes/+release-detect-race.bugfix
+++ b/changes/+release-detect-race.bugfix
@@ -1,1 +1,0 @@
-Fix release workflow race condition: detect version from merge commit message instead of relying on GitHub API that may not be indexed yet.

--- a/changes/+status-watch.feature
+++ b/changes/+status-watch.feature
@@ -1,1 +1,0 @@
-Add --watch mode, --interval flag, state color mapping, and progress bar to ``bambox status``.

--- a/changes/+validation-reference.feature
+++ b/changes/+validation-reference.feature
@@ -1,1 +1,0 @@
-Add validation checks E013-E014 (multi-filament tool changes), W012-W014 (temperature/matrix ranges), --reference comparison mode (C001-C005), and release-readiness tests.

--- a/changes/109.misc
+++ b/changes/109.misc
@@ -1,1 +1,0 @@
-Add THIRD-PARTY-NOTICES file with license attribution for bundled CuraEngine definitions and OrcaSlicer/BambuStudio-derived profiles.

--- a/changes/80.misc
+++ b/changes/80.misc
@@ -1,1 +1,0 @@
-Improve bridge.py test coverage for credentials, AMS parsing, 3MF stripping, and cloud print.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/bambox"]
 
 [project]
 name = "bambox"
-version = "0.2.2"
+version = "0.3.0rc1"
 description = "Package plain G-code into Bambu Lab .gcode.3mf files"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Release v0.3.0rc1


### Features

- Add --watch mode, --interval flag, state color mapping, and progress bar to ``bambox status``.
- Add ``bambox --version`` / ``bambox -V`` flag that reports the installed package version.
- Add validation checks E013-E014 (multi-filament tool changes), W012-W014 (temperature/matrix ranges), --reference comparison mode (C001-C005), and release-readiness tests.
- Show AMS filament slot mapping in `bambox print` output so users can verify tray assignments before printing.
- Wire WasCancelledFn through the Rust bridge so in-flight uploads can be cancelled via the /cancel endpoint

### Bugfixes

- Fix "Compatible Printer" showing repeated X1 Carbon instead of P1S in Bambu Connect by moving machine-level list keys out of per-filament varying keys.
- Fix CuraEngine bed type mapping (textured_pei_plate → Textured PEI Plate) and sync M73 remaining-time markers with purge-compensated prediction in slice_info.
- Fix release workflow race condition: detect version from merge commit message instead of relying on GitHub API that may not be indexed yet.
- Pass --user uid:gid to Docker bridge containers and pull image before each run
- Populate per-filament usage (used_m/used_g) in slice_info by tracking extrusion per extruder from G-code E positions.

### Misc

- Improve bridge.py test coverage for credentials, AMS parsing, 3MF stripping, and cloud print. ([#80](https://github.com/estampo/bambox/pull/80))
- Add THIRD-PARTY-NOTICES file with license attribution for bundled CuraEngine definitions and OrcaSlicer/BambuStudio-derived profiles. ([#109](https://github.com/estampo/bambox/pull/109))
- Harden install.sh with partial-execution protection, temp file cleanup, sudo handling, and dependency checks
- Support pre-release versions (rc, alpha, beta) in release workflows

---
**Merge this PR to trigger the release pipeline.**
The release workflow will build the package, validate on TestPyPI, create the tag, create the GitHub Release, then publish to PyPI.