### PR TITLE
Fix baked Docker fallback permissions for --user uid:gid

### DIFF
--- a/changes/+baked-docker-perms.bugfix
+++ b/changes/+baked-docker-perms.bugfix
@@ -1,0 +1,1 @@
+Fix baked Docker fallback permissions so bridge runs correctly with --user uid:gid

--- a/src/bambox/bridge.py
+++ b/src/bambox/bridge.py
@@ -231,10 +231,13 @@ def _run_bridge_baked(
     try:
         # Write Dockerfile
         lines = [f"FROM {DOCKER_IMAGE}"]
+        # Ensure writable dirs the Bambu Network Library expects
+        lines.append("RUN chmod -R 777 /tmp/bambu_agent /tmp/bambu_plugin")
         for host_path, container_path in file_args.items():
             basename = os.path.basename(host_path)
             shutil.copy2(host_path, tmpdir / basename)
             lines.append(f"COPY {basename} {container_path}")
+            lines.append(f"RUN chmod 644 {container_path}")
         (tmpdir / "Dockerfile").write_text("\n".join(lines) + "\n")
 
         tag = "bambox-bridge-tmp"

--- a/tests/test_bridge_docker.py
+++ b/tests/test_bridge_docker.py
@@ -244,4 +244,6 @@ class TestRunBridgeBaked:
         assert len(dockerfiles_written) == 1
         df = dockerfiles_written[0]
         assert df.startswith(f"FROM {DOCKER_IMAGE}")
+        assert "RUN chmod -R 777 /tmp/bambu_agent /tmp/bambu_plugin" in df
         assert "COPY test.3mf /input/test.3mf" in df
+        assert "RUN chmod 644 /input/test.3mf" in df


### PR DESCRIPTION
## Summary
- Add `RUN chmod -R 777 /tmp/bambu_agent /tmp/bambu_plugin` to the generated Dockerfile so the Bambu Network Library can write to its runtime dirs when running as non-root
- Add `RUN chmod 644` for each COPY'd file so the bridge process can read input files
- Verified end-to-end against a live P1S printer in a sandboxed (overlay FS) environment

## Test plan
- [x] `uv run pytest tests/test_bridge_docker.py` — 12 passed
- [x] `uv run pytest` — 559 passed
- [x] `bambox status` returns live printer data via baked fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)