### PR TITLE
Trigger bridge binary build from release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,3 +244,23 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true
+
+  # ── Trigger bridge binary build ─────────────────────────────────────
+  # Tags created by GITHUB_TOKEN don't trigger other workflows, so we
+  # explicitly dispatch the bridge build to attach native binaries to
+  # the release.
+  build-bridge:
+    needs: [version, create-tag]
+    if: |
+      always() &&
+      needs.version.result == 'success' &&
+      needs.create-tag.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger bridge build
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          gh workflow run build-bridge.yml \
+            --repo "${{ github.repository }}" \
+            --ref "v${{ needs.version.outputs.version }}"

--- a/changes/+release-bridge-binaries.bugfix
+++ b/changes/+release-bridge-binaries.bugfix
@@ -1,0 +1,1 @@
+Trigger bridge binary build from release pipeline so native binaries are attached to GitHub Releases


### PR DESCRIPTION
## Summary
- Tags created by `GITHUB_TOKEN` don't trigger other workflows, so `build-bridge.yml` never ran on release tags
- Add an explicit `workflow_dispatch` trigger from `release.yml` after tag creation, using `RELEASE_PAT` to bypass the anti-recursion restriction
- This ensures native bridge binaries (`bambox-bridge-linux-x86_64`, `bambox-bridge-macos-*`) are attached to every GitHub Release

## Test plan
- [ ] Verify next release creates bridge binaries on the GitHub Release
- [ ] Manually trigger `build-bridge.yml` on `v0.3.0rc1` tag to backfill current release

🤖 Generated with [Claude Code](https://claude.com/claude-code)