### PR TITLE
Remove --user from bridge Docker calls

### DIFF
--- a/changes/+baked-docker-perms.bugfix
+++ b/changes/+baked-docker-perms.bugfix
@@ -1,1 +1,1 @@
-Fix baked Docker fallback permissions so bridge runs correctly with --user uid:gid
+Remove ``--user`` from bridge Docker calls (bridge has no host-side output files) and increase status timeout to accommodate baked fallback path

--- a/src/bambox/bridge.py
+++ b/src/bambox/bridge.py
@@ -187,8 +187,6 @@ def _run_bridge_docker(
     # Collect local file paths for potential bake fallback
     file_args: dict[str, str] = {}  # host_path -> container_path
     cmd: list[str] = ["docker", "run", "--rm", "--platform", "linux/amd64"]
-    if hasattr(os, "getuid"):
-        cmd.extend(["--user", f"{os.getuid()}:{os.getgid()}"])
     docker_args: list[str] = []
     for arg in args:
         if os.path.exists(arg):
@@ -231,13 +229,10 @@ def _run_bridge_baked(
     try:
         # Write Dockerfile
         lines = [f"FROM {DOCKER_IMAGE}"]
-        # Ensure writable dirs the Bambu Network Library expects
-        lines.append("RUN chmod -R 777 /tmp/bambu_agent /tmp/bambu_plugin")
         for host_path, container_path in file_args.items():
             basename = os.path.basename(host_path)
             shutil.copy2(host_path, tmpdir / basename)
             lines.append(f"COPY {basename} {container_path}")
-            lines.append(f"RUN chmod 644 {container_path}")
         (tmpdir / "Dockerfile").write_text("\n".join(lines) + "\n")
 
         tag = "bambox-bridge-tmp"
@@ -261,8 +256,6 @@ def _run_bridge_baked(
                 docker_args.append(arg)
 
         cmd = ["docker", "run", "--rm", "--platform", "linux/amd64"]
-        if hasattr(os, "getuid"):
-            cmd.extend(["--user", f"{os.getuid()}:{os.getgid()}"])
         cmd.append(tag)
         cmd.extend(docker_args)
         if verbose:
@@ -485,7 +478,7 @@ def query_status(
     """Query live printer status via the bridge."""
     result = _run_bridge(
         ["status", device_id, str(token_file.resolve())],
-        timeout=60,
+        timeout=120,
         verbose=verbose,
     )
     try:

--- a/tests/test_bridge_docker.py
+++ b/tests/test_bridge_docker.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
@@ -14,8 +13,6 @@ from bambox.bridge import (
     _run_bridge_baked,
     _run_bridge_docker,
 )
-
-_HAS_GETUID = hasattr(os, "getuid")
 
 # -- _run_bridge_docker --------------------------------------------------------
 
@@ -51,7 +48,7 @@ class TestRunBridgeDocker:
             assert cmd[1] == "run"
             assert "--rm" in cmd
             assert "--platform" in cmd
-            assert ("--user" in cmd) == _HAS_GETUID
+            assert "--user" not in cmd
             assert DOCKER_IMAGE in cmd
             assert "status" in cmd
             assert "DEV1" in cmd
@@ -177,11 +174,11 @@ class TestRunBridgeBaked:
             build_cmd = build_call[0][0]
             assert build_cmd[:3] == ["docker", "build", "-t"]
 
-            # Verify docker run was called (with --user on Unix)
+            # Verify docker run was called (without --user — bridge has no host output)
             run_call = mock_run.call_args_list[1]
             run_cmd = run_call[0][0]
             assert run_cmd[0:2] == ["docker", "run"]
-            assert ("--user" in run_cmd) == _HAS_GETUID
+            assert "--user" not in run_cmd
             assert "/input/test.3mf" in run_cmd
 
             # Verify cleanup (docker rmi)
@@ -244,6 +241,4 @@ class TestRunBridgeBaked:
         assert len(dockerfiles_written) == 1
         df = dockerfiles_written[0]
         assert df.startswith(f"FROM {DOCKER_IMAGE}")
-        assert "RUN chmod -R 777 /tmp/bambu_agent /tmp/bambu_plugin" in df
         assert "COPY test.3mf /input/test.3mf" in df
-        assert "RUN chmod 644 /input/test.3mf" in df


### PR DESCRIPTION
## Summary
- Remove `--user uid:gid` from both bind-mount and baked Docker paths — the bridge has no host-side output files (returns JSON on stdout only), and the Bambu Network Library needs to write to root-owned `/tmp/bambu_agent` and `/tmp/bambu_plugin`
- Bump `query_status` timeout from 60s to 120s to accommodate the baked fallback path (bind-mount attempt + docker build + MQTT connect)
- Tested end-to-end against live P1S printer

Fixes the `boost::filesystem::create_directory: Permission denied` crash on both macOS and Linux.

## Test plan
- [x] `bambox status` returns live printer data
- [x] `uv run pytest tests/test_bridge_docker.py tests/test_bridge.py` — 47 passed
- [x] All lint/format/mypy checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)