### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ This changelog is managed by [towncrier](https://towncrier.readthedocs.io/).
 
 <!-- towncrier release notes start -->
 
+## 0.3.0 — 2026-04-10
+
+### Bugfixes
+
+- Remove ``--user`` from bridge Docker calls (bridge has no host-side output files) and increase status timeout to accommodate baked fallback path
+- Trigger bridge binary build from release pipeline so native binaries are attached to GitHub Releases
+
+### Misc
+
+- Update README with full CLI documentation for all subcommands
+
+
 ## 0.3.0rc1 — 2026-04-10
 
 ### Features

--- a/changes/+baked-docker-perms.bugfix
+++ b/changes/+baked-docker-perms.bugfix
@@ -1,1 +1,0 @@
-Remove ``--user`` from bridge Docker calls (bridge has no host-side output files) and increase status timeout to accommodate baked fallback path

--- a/changes/+readme-cli-docs.misc
+++ b/changes/+readme-cli-docs.misc
@@ -1,1 +1,0 @@
-Update README with full CLI documentation for all subcommands

--- a/changes/+release-bridge-binaries.bugfix
+++ b/changes/+release-bridge-binaries.bugfix
@@ -1,1 +1,0 @@
-Trigger bridge binary build from release pipeline so native binaries are attached to GitHub Releases

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/bambox"]
 
 [project]
 name = "bambox"
-version = "0.3.0rc1"
+version = "0.3.0"
 description = "Package plain G-code into Bambu Lab .gcode.3mf files"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Release v0.3.0


### Bugfixes

- Remove ``--user`` from bridge Docker calls (bridge has no host-side output files) and increase status timeout to accommodate baked fallback path
- Trigger bridge binary build from release pipeline so native binaries are attached to GitHub Releases

### Misc

- Update README with full CLI documentation for all subcommands

---
**Merge this PR to trigger the release pipeline.**
The release workflow will build the package, validate on TestPyPI, create the tag, create the GitHub Release, then publish to PyPI.