### PR TITLE
Fix tag-exists check: exact match instead of prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           fi
 
           if [[ -n "$VERSION" ]]; then
-            if gh api "repos/${{ github.repository }}/git/refs/tags/v${VERSION}" >/dev/null 2>&1; then
+            if git ls-remote --tags origin "refs/tags/v${VERSION}" | grep -q .; then
               echo "::warning::Tag v${VERSION} already exists — skipping"
               echo "is_release=false" >> "$GITHUB_OUTPUT"
             else
@@ -160,7 +160,7 @@ jobs:
       - name: Create and push tag (if it doesn't exist)
         run: |
           VERSION="${{ needs.version.outputs.version }}"
-          if gh api "repos/${{ github.repository }}/git/refs/tags/v${VERSION}" >/dev/null 2>&1; then
+          if git ls-remote --tags origin "refs/tags/v${VERSION}" | grep -q .; then
             echo "::notice::Tag v${VERSION} already exists — skipping"
           else
             git tag "v${VERSION}"

--- a/changes/+fix-tag-prefix-match.bugfix
+++ b/changes/+fix-tag-prefix-match.bugfix
@@ -1,0 +1,1 @@
+Fix release pipeline false-positive tag detection when a pre-release tag exists (e.g. v0.3.0rc1 blocked v0.3.0)


### PR DESCRIPTION
## Summary
- The GitHub API `git/refs/tags/v0.3.0` returns all tags with that prefix, including `v0.3.0rc1`
- This caused the v0.3.0 release to be skipped ("Tag already exists") because the rc1 tag matched
- Switch to `git ls-remote --tags` which matches exact ref names

## Test plan
- [ ] Merge this, then re-run the release workflow for v0.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)