### PR TITLE
Fix validate false positives on bambox-generated archives

### DIFF
--- a/changes/+fix-validate-false-positives.bugfix
+++ b/changes/+fix-validate-false-positives.bugfix
@@ -1,0 +1,1 @@
+Fix E014 false positive on initial extruder select and W013 false positive on BBL ``-1`` disabled sentinel

--- a/src/bambox/cli.py
+++ b/src/bambox/cli.py
@@ -980,5 +980,6 @@ def status(
 def main(argv: list[str] | None = None) -> None:
     try:
         app(argv, standalone_mode=False)
-    except click.UsageError:
+    except click.UsageError as exc:
+        ui.error(str(exc))
         sys.exit(2)

--- a/src/bambox/validate.py
+++ b/src/bambox/validate.py
@@ -448,12 +448,18 @@ def _check_multi_filament(gcode: str, findings: list[Finding]) -> None:
         )
 
     # E014: bare T commands outside M620/M621 blocks
-    # Walk lines tracking whether we are inside an M620/M621 block
+    # Walk lines tracking whether we are inside an M620/M621 block.
+    # The first bare T command before any extrusion (G1 … E) is an initial
+    # extruder select left by rewrite_tool_changes — harmless, skip it.
+    _RE_EXTRUSION = re.compile(r"^G1\s.*E[\d.]")
     in_block = False
+    seen_extrusion = False
     for line in gcode.splitlines():
         stripped = line.strip()
         if stripped.startswith(";"):
             continue
+        if not seen_extrusion and _RE_EXTRUSION.match(stripped):
+            seen_extrusion = True
         if _RE_M620_S.match(stripped):
             in_block = True
             continue
@@ -461,6 +467,8 @@ def _check_multi_filament(gcode: str, findings: list[Finding]) -> None:
             in_block = False
             continue
         if not in_block and _RE_BARE_TOOL.match(stripped):
+            if not seen_extrusion:
+                continue  # initial extruder select, not a real tool change
             findings.append(
                 Finding(
                     Severity.ERROR,
@@ -618,6 +626,8 @@ def _check_project_settings(raw: str, findings: list[Finding]) -> None:
                 temp = int(v) if isinstance(v, str) else int(v)
             except (ValueError, TypeError):
                 continue
+            if temp == -1:
+                continue  # BBL firmware sentinel for "disabled"
             if temp < 0 or temp > 120:
                 findings.append(
                     Finding(

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -763,6 +763,39 @@ G1 X20 Y20 E2 F600
         result = validate_3mf(path)
         assert any(f.code == "E014" for f in result.errors)
 
+    def test_initial_extruder_select_ok(self, tmp_path: Path) -> None:
+        """Bare T0 before any extrusion is an initial select, not an error."""
+        gcode = """\
+; HEADER_BLOCK_START
+; total layer number: 2
+; HEADER_BLOCK_END
+M73 P0 R5
+T0
+M620 S0
+T0
+M621 S0
+;LAYER_CHANGE
+;Z:0.2
+;HEIGHT:0.2
+M73 L1
+M991 S0 P1
+M73 P50 R3
+G1 X10 Y10 E1 F600
+M620 S1
+T1
+M621 S1
+;LAYER_CHANGE
+;Z:0.4
+;HEIGHT:0.2
+M73 L2
+M991 S0 P2
+M73 P100 R0
+G1 X20 Y20 E2 F600
+"""
+        path = _build_valid_3mf(tmp_path, gcode=gcode)
+        result = validate_3mf(path)
+        assert not any(f.code == "E014" for f in result.findings)
+
     def test_t_inside_block_ok(self, tmp_path: Path) -> None:
         """T commands inside M620/M621 blocks should not trigger E014."""
         path = _build_valid_3mf(tmp_path, gcode=_MULTI_FILAMENT_GCODE)
@@ -818,6 +851,23 @@ class TestBedTempRange:
         path = _build_valid_3mf(tmp_path, settings=settings)
         result = validate_3mf(path)
         assert any(f.code == "W013" for f in result.warnings)
+
+    def test_disabled_sentinel_minus_one_ok(self, tmp_path: Path) -> None:
+        """BBL firmware uses -1 to mean 'disabled' — not an out-of-range temp."""
+        settings = json.dumps(
+            {
+                "filament_type": ["PLA"] * 5,
+                "filament_colour": ["#F2754E"] * 5,
+                "nozzle_temperature": ["220"] * 5,
+                "nozzle_temperature_initial_layer": ["220"] * 5,
+                "bed_temperature": ["60"] * 5,
+                "filament_max_volumetric_speed": ["12"] * 5,
+                "filament_tower_interface_print_temp": ["-1"] * 5,
+            }
+        )
+        path = _build_valid_3mf(tmp_path, settings=settings)
+        result = validate_3mf(path)
+        assert not any(f.code == "W013" for f in result.findings)
 
     def test_valid_bed_temp_passes(self, tmp_path: Path) -> None:
         path = _build_valid_3mf(tmp_path)


### PR DESCRIPTION
## Summary
- **E014**: Skip bare `T` commands that appear before any extrusion move — these are initial extruder selects left by `rewrite_tool_changes`, not real tool change errors
- **W013**: Allow `-1` as a valid temperature value — BBL firmware uses it as a "disabled" sentinel (e.g. `filament_tower_interface_print_temp`)

## Test plan
- [ ] New test: `test_initial_extruder_select_ok` — bare T0 before extrusion doesn't trigger E014
- [ ] New test: `test_disabled_sentinel_minus_one_ok` — `-1` temp values don't trigger W013
- [ ] Existing E014/W013 tests still pass (real violations still caught)
- [ ] Validate a bambox 0.3.0 cura-ams-p1s archive — no false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)