### PR TITLE
Fix E014 false positive on redundant extruder re-select

### DIFF
--- a/changes/+fix-e014-redundant-select.bugfix
+++ b/changes/+fix-e014-redundant-select.bugfix
@@ -1,0 +1,1 @@
+Fix E014 false positive on redundant extruder re-select after M620/M621 block

--- a/src/bambox/validate.py
+++ b/src/bambox/validate.py
@@ -449,35 +449,38 @@ def _check_multi_filament(gcode: str, findings: list[Finding]) -> None:
 
     # E014: bare T commands outside M620/M621 blocks
     # Walk lines tracking whether we are inside an M620/M621 block.
-    # The first bare T command before any extrusion (G1 … E) is an initial
-    # extruder select left by rewrite_tool_changes — harmless, skip it.
-    _RE_EXTRUSION = re.compile(r"^G1\s.*E[\d.]")
+    # rewrite_tool_changes leaves the first T command (initial extruder
+    # select) as a bare line.  It always matches the last M620 block's
+    # extruder, so skip bare T commands that re-select the current tool.
     in_block = False
-    seen_extrusion = False
+    last_block_ext: int | None = None
     for line in gcode.splitlines():
         stripped = line.strip()
         if stripped.startswith(";"):
             continue
-        if not seen_extrusion and _RE_EXTRUSION.match(stripped):
-            seen_extrusion = True
-        if _RE_M620_S.match(stripped):
+        m620 = _RE_M620_S.match(stripped)
+        if m620:
             in_block = True
+            last_block_ext = int(m620.group(1))
             continue
         if _RE_M621_S.match(stripped):
             in_block = False
             continue
-        if not in_block and _RE_BARE_TOOL.match(stripped):
-            if not seen_extrusion:
-                continue  # initial extruder select, not a real tool change
-            findings.append(
-                Finding(
-                    Severity.ERROR,
-                    "E014",
-                    "Bare tool command outside M620/M621 block in multi-filament print",
-                    stripped[:120],
+        if not in_block:
+            m_tool = _RE_BARE_TOOL.match(stripped)
+            if m_tool:
+                ext = int(m_tool.group(1))
+                if ext == last_block_ext:
+                    continue  # redundant select of current extruder
+                findings.append(
+                    Finding(
+                        Severity.ERROR,
+                        "E014",
+                        "Bare tool command outside M620/M621 block in multi-filament print",
+                        stripped[:120],
+                    )
                 )
-            )
-            return  # one finding is enough
+                return  # one finding is enough
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -763,17 +763,21 @@ G1 X20 Y20 E2 F600
         result = validate_3mf(path)
         assert any(f.code == "E014" for f in result.errors)
 
-    def test_initial_extruder_select_ok(self, tmp_path: Path) -> None:
-        """Bare T0 before any extrusion is an initial select, not an error."""
+    def test_redundant_extruder_select_ok(self, tmp_path: Path) -> None:
+        """Bare T0 re-selecting current extruder after M620 S0 block is harmless."""
         gcode = """\
 ; HEADER_BLOCK_START
 ; total layer number: 2
 ; HEADER_BLOCK_END
 M73 P0 R5
-T0
 M620 S0
 T0
 M621 S0
+G1 X10 Y10 E1 F600
+T0
+M620 S1
+T1
+M621 S1
 ;LAYER_CHANGE
 ;Z:0.2
 ;HEIGHT:0.2
@@ -781,9 +785,6 @@ M73 L1
 M991 S0 P1
 M73 P50 R3
 G1 X10 Y10 E1 F600
-M620 S1
-T1
-M621 S1
 ;LAYER_CHANGE
 ;Z:0.4
 ;HEIGHT:0.2


### PR DESCRIPTION
## Summary
- Fixes remaining E014 false positive on bambox-generated archives
- The previous fix (#132) checked for extrusion before the bare T command, but start gcode already has extrusion moves before the toolpath begins
- New approach: track the last extruder selected by an M620/M621 block and skip bare T commands that re-select the same extruder (redundant no-op)

## Test plan
- [ ] `test_redundant_extruder_select_ok` — bare T0 after M620 S0 block doesn't trigger E014
- [ ] `test_bare_t_outside_block` — bare T1 (different extruder) still triggers E014
- [ ] Validate bambox 0.3.0 cura-ams-p1s archive — no false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)