### PR TITLE
Fix README badges pointing to wrong PyPI package

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![CI](https://github.com/estampo/bambox/actions/workflows/ci.yml/badge.svg)](https://github.com/estampo/bambox/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/estampo/bambox/branch/main/graph/badge.svg)](https://codecov.io/gh/estampo/bambox)
-[![PyPI version](https://img.shields.io/pypi/v/bambu-3mf)](https://pypi.org/project/bambu-3mf/)
-[![Python versions](https://img.shields.io/pypi/pyversions/bambu-3mf)](https://pypi.org/project/bambu-3mf/)
+[![PyPI version](https://img.shields.io/pypi/v/bambox)](https://pypi.org/project/bambox/)
+[![Python versions](https://img.shields.io/pypi/pyversions/bambox)](https://pypi.org/project/bambox/)
 
 > **Experimental software — use at your own risk.**
 > bambox talks directly to Bambu Lab printer firmware. Incorrect packaging,

--- a/changes/+fix-readme-badges.misc
+++ b/changes/+fix-readme-badges.misc
@@ -1,0 +1,1 @@
+Fix PyPI badges in README pointing to wrong package name


### PR DESCRIPTION
## Summary
- PyPI badges pointed to `bambu-3mf` (404) instead of `bambox`

## Test plan
- [ ] Badges render on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)