### PR TITLE
Add bambox cancel command

### DIFF
--- a/changes/+cancel-command.feature
+++ b/changes/+cancel-command.feature
@@ -1,0 +1,1 @@
+Add ``bambox cancel`` command to stop the current print on a Bambu printer

--- a/src/bambox/bridge.py
+++ b/src/bambox/bridge.py
@@ -491,6 +491,44 @@ def query_status(
         )
 
 
+def cancel_print(
+    device_id: str,
+    credentials: dict[str, str] | None = None,
+    credentials_path: Path | None = None,
+    *,
+    verbose: bool = False,
+) -> dict:
+    """Cancel the current print on a Bambu printer via cloud bridge.
+
+    Either *credentials* (dict) or *credentials_path* (TOML file) must be given.
+
+    Returns the bridge response dict.
+    """
+    if credentials is None:
+        credentials = load_credentials(credentials_path)
+
+    token_file = _write_token_json(credentials)
+    try:
+        result = _run_bridge(
+            ["cancel", device_id, str(token_file.resolve())],
+            timeout=120,
+            verbose=verbose,
+        )
+    finally:
+        try:
+            token_file.unlink()
+        except OSError:
+            pass
+
+    try:
+        return json.loads(result.stdout.strip())
+    except json.JSONDecodeError:
+        raise RuntimeError(
+            f"Bridge returned non-JSON (exit {result.returncode}): "
+            f"{result.stdout[:200]} | {result.stderr[:200]}"
+        )
+
+
 def cloud_print(
     threemf_path: Path,
     device_id: str,

--- a/src/bambox/cli.py
+++ b/src/bambox/cli.py
@@ -930,6 +930,54 @@ def print_cmd(
 
 
 @app.command()
+def cancel(
+    device: Annotated[str, typer.Option("-d", "--device", help="Printer serial number")] = "",
+    printer: Annotated[
+        Optional[str], typer.Option("-p", "--printer", help="Named printer from credentials.toml")
+    ] = None,
+    credentials: Annotated[
+        Optional[Path], typer.Option("-c", "--credentials", help="Path to credentials.toml")
+    ] = None,
+) -> None:
+    """Cancel the current print on a Bambu printer."""
+    _warn_experimental()
+    from bambox.bridge import cancel_print, load_credentials
+
+    creds_path = credentials
+    try:
+        creds = load_credentials(creds_path)
+    except (FileNotFoundError, ValueError) as e:
+        ui.error(str(e))
+        sys.exit(1)
+
+    serial = device
+    if not serial:
+        if printer:
+            serial, name = _resolve_printer(printer, creds_path)
+        else:
+            serial, name = _resolve_printer(None, creds_path)
+
+    if not serial:
+        ui.error("No printer specified. Use --device or --printer.")
+        sys.exit(1)
+
+    if not ui.prompt_yn("Cancel the current print?", default=False):
+        ui.info("Cancelled.")
+        return
+
+    try:
+        result = cancel_print(serial, credentials=creds, verbose=_verbose)
+        resp = result.get("result", "unknown")
+        if resp in ("success", "ok"):
+            ui.success("Print cancelled.")
+        else:
+            ui.console.print(f"Bridge response: {json.dumps(result, indent=2)}", markup=False)
+    except Exception as e:
+        ui.error(str(e))
+        sys.exit(1)
+
+
+@app.command()
 def status(
     device: Annotated[str, typer.Argument(help="Printer serial number")] = "",
     printer: Annotated[

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -502,6 +502,56 @@ class TestCmdPrint:
 
 
 # ---------------------------------------------------------------------------
+# cancel via main()
+# ---------------------------------------------------------------------------
+
+
+class TestCmdCancel:
+    def test_cancel_bad_credentials(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with patch("bambox.bridge.load_credentials", side_effect=FileNotFoundError("no creds")):
+            with pytest.raises(SystemExit, match="1"):
+                main(["cancel", "-d", "SERIAL"])
+        assert "no creds" in capsys.readouterr().err
+
+    def test_cancel_success(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        creds = {"token": "tok"}
+        with (
+            patch("bambox.bridge.load_credentials", return_value=creds),
+            patch("bambox.bridge.cancel_print", return_value={"result": "success"}) as mock_cp,
+            patch("bambox.cli.ui.prompt_yn", return_value=True),
+        ):
+            main(["cancel", "-d", "SERIAL123"])
+            assert mock_cp.call_args[0][0] == "SERIAL123"
+        assert "cancelled" in capsys.readouterr().out.lower()
+
+    def test_cancel_aborted_by_user(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        creds = {"token": "tok"}
+        with (
+            patch("bambox.bridge.load_credentials", return_value=creds),
+            patch("bambox.bridge.cancel_print") as mock_cp,
+            patch("bambox.cli.ui.prompt_yn", return_value=False),
+        ):
+            main(["cancel", "-d", "SERIAL123"])
+            mock_cp.assert_not_called()
+
+    def test_cancel_by_printer_name(self, tmp_path: Path) -> None:
+        creds_file = tmp_path / "credentials.toml"
+        creds_file.write_text('[cloud]\ntoken = "tok"\n[printers.myprinter]\nserial = "ABC123"\n')
+        creds = {"token": "tok"}
+        with (
+            patch("bambox.bridge.load_credentials", return_value=creds),
+            patch("bambox.bridge.cancel_print", return_value={"result": "ok"}) as mock_cp,
+            patch("bambox.cli.ui.prompt_yn", return_value=True),
+        ):
+            main(["cancel", "-p", "myprinter", "-c", str(creds_file)])
+            assert mock_cp.call_args[0][0] == "ABC123"
+
+
+# ---------------------------------------------------------------------------
 # _cmd_status via main()
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- New `bambox cancel` CLI command to stop the current print on a Bambu printer
- New `cancel_print()` function in `bridge.py` public API
- Confirmation prompt before sending cancel (default: no)
- Supports `-d/--device` and `-p/--printer` for printer selection

Usage:
```bash
bambox cancel -d DEVICE_SERIAL
bambox cancel -p my_printer
```

## Test plan
- [x] `test_cancel_bad_credentials` — exits with error on missing creds
- [x] `test_cancel_success` — sends cancel, shows success message
- [x] `test_cancel_aborted_by_user` — user says no, bridge not called
- [x] `test_cancel_by_printer_name` — resolves printer name to serial

🤖 Generated with [Claude Code](https://claude.com/claude-code)