### PR TITLE
Include install.sh in release assets

### DIFF
--- a/.github/workflows/build-bridge.yml
+++ b/.github/workflows/build-bridge.yml
@@ -51,6 +51,7 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v6
       - uses: actions/download-artifact@v4
         with:
           path: dist
@@ -67,3 +68,5 @@ jobs:
             mv "/tmp/$name" "dist/$name"
             gh release upload "$TAG" "dist/$name" --repo "${{ github.repository }}" --clobber
           done
+          # Upload install script
+          gh release upload "$TAG" install.sh --repo "${{ github.repository }}" --clobber

--- a/changes/+install-script-release.bugfix
+++ b/changes/+install-script-release.bugfix
@@ -1,0 +1,1 @@
+Include ``install.sh`` in GitHub release assets so the bridge install command works


### PR DESCRIPTION
## Summary
- The bridge install command (`curl -fsSL .../install.sh | sh`) returned 404 because `install.sh` was not included in release assets
- Added `actions/checkout@v6` step and `gh release upload` for `install.sh` in `build-bridge.yml`
- Also manually uploaded `install.sh` to the v0.3.0 release so it works now

## Test plan
- [ ] `curl -fsSL https://github.com/estampo/bambox/releases/latest/download/install.sh | sh` works
- [ ] Future releases include install.sh automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)