### PR TITLE
Release v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ This changelog is managed by [towncrier](https://towncrier.readthedocs.io/).
 
 <!-- towncrier release notes start -->
 
+## 0.3.5 — 2026-04-11
+
+### Features
+
+- Bring ``bambox status`` display to parity with estampo TUI: rounded temperatures, color swatches, print stages, and active tray indicator ([#131](https://github.com/estampo/bambox/pull/131))
+- Add ``bambox cancel`` command to stop the current print on a Bambu printer
+- Migrate CLI from argparse to Typer + Rich for consistent TUI rendering with estampo, including shell completion support
+
+### Bugfixes
+
+- Bridge binary now checks ``~/.config/bambox/`` for credentials (preferred over legacy ``~/.config/estampo/``)
+- Fix E014 false positive on initial extruder select and W013 false positive on BBL ``-1`` disabled sentinel
+- Fix E014 false positive on redundant extruder re-select after M620/M621 block
+- Fix release pipeline false-positive tag detection when a pre-release tag exists (e.g. v0.3.0rc1 blocked v0.3.0)
+- Include ``install.sh`` in GitHub release assets so the bridge install command works
+
+### Misc
+
+- Add CuraEngine + P1S AMS usage guide
+- Fix PyPI badges in README pointing to wrong package name
+- Update README: add experimental warning, bridge install instructions, platform support table, remove bambu-cloud references
+
+
 ## 0.3.0 — 2026-04-10
 
 ### Bugfixes

--- a/changes/+bridge-credentials-bambox.bugfix
+++ b/changes/+bridge-credentials-bambox.bugfix
@@ -1,1 +1,0 @@
-Bridge binary now checks ``~/.config/bambox/`` for credentials (preferred over legacy ``~/.config/estampo/``)

--- a/changes/+cancel-command.feature
+++ b/changes/+cancel-command.feature
@@ -1,1 +1,0 @@
-Add ``bambox cancel`` command to stop the current print on a Bambu printer

--- a/changes/+cura-ams-guide.misc
+++ b/changes/+cura-ams-guide.misc
@@ -1,1 +1,0 @@
-Add CuraEngine + P1S AMS usage guide

--- a/changes/+fix-e014-redundant-select.bugfix
+++ b/changes/+fix-e014-redundant-select.bugfix
@@ -1,1 +1,0 @@
-Fix E014 false positive on redundant extruder re-select after M620/M621 block

--- a/changes/+fix-readme-badges.misc
+++ b/changes/+fix-readme-badges.misc
@@ -1,1 +1,0 @@
-Fix PyPI badges in README pointing to wrong package name

--- a/changes/+fix-tag-prefix-match.bugfix
+++ b/changes/+fix-tag-prefix-match.bugfix
@@ -1,1 +1,0 @@
-Fix release pipeline false-positive tag detection when a pre-release tag exists (e.g. v0.3.0rc1 blocked v0.3.0)

--- a/changes/+fix-validate-false-positives.bugfix
+++ b/changes/+fix-validate-false-positives.bugfix
@@ -1,1 +1,0 @@
-Fix E014 false positive on initial extruder select and W013 false positive on BBL ``-1`` disabled sentinel

--- a/changes/+install-script-release.bugfix
+++ b/changes/+install-script-release.bugfix
@@ -1,1 +1,0 @@
-Include ``install.sh`` in GitHub release assets so the bridge install command works

--- a/changes/+readme-update.misc
+++ b/changes/+readme-update.misc
@@ -1,1 +1,0 @@
-Update README: add experimental warning, bridge install instructions, platform support table, remove bambu-cloud references

--- a/changes/+typer-rich-cli.feature
+++ b/changes/+typer-rich-cli.feature
@@ -1,1 +1,0 @@
-Migrate CLI from argparse to Typer + Rich for consistent TUI rendering with estampo, including shell completion support

--- a/changes/131.feature
+++ b/changes/131.feature
@@ -1,1 +1,0 @@
-Bring ``bambox status`` display to parity with estampo TUI: rounded temperatures, color swatches, print stages, and active tray indicator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/bambox"]
 
 [project]
 name = "bambox"
-version = "0.3.0"
+version = "0.3.5"
 description = "Package plain G-code into Bambu Lab .gcode.3mf files"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Release v0.3.5


### Features

- Bring ``bambox status`` display to parity with estampo TUI: rounded temperatures, color swatches, print stages, and active tray indicator ([#131](https://github.com/estampo/bambox/pull/131))
- Add ``bambox cancel`` command to stop the current print on a Bambu printer
- Migrate CLI from argparse to Typer + Rich for consistent TUI rendering with estampo, including shell completion support

### Bugfixes

- Bridge binary now checks ``~/.config/bambox/`` for credentials (preferred over legacy ``~/.config/estampo/``)
- Fix E014 false positive on initial extruder select and W013 false positive on BBL ``-1`` disabled sentinel
- Fix E014 false positive on redundant extruder re-select after M620/M621 block
- Fix release pipeline false-positive tag detection when a pre-release tag exists (e.g. v0.3.0rc1 blocked v0.3.0)
- Include ``install.sh`` in GitHub release assets so the bridge install command works

### Misc

- Add CuraEngine + P1S AMS usage guide
- Fix PyPI badges in README pointing to wrong package name
- Update README: add experimental warning, bridge install instructions, platform support table, remove bambu-cloud references

---
**Merge this PR to trigger the release pipeline.**
The release workflow will build the package, validate on TestPyPI, create the tag, create the GitHub Release, then publish to PyPI.