### PR TITLE
Document Rust bridge as replacement for C++ estampo/cloud-bridge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Each module has a defined scope. Do not add logic to the wrong module — even i
 |--------|------|-----------------|
 | `pack.py` | Core .gcode.3mf archive construction, XML metadata, MD5 checksums, Bambu Connect fixup | Settings generation, slicer logic, printer communication |
 | `settings.py` | 544-key project_settings builder, profile loading, filament overlay, array broadcasting | G-code generation, archive packing, printer logic |
-| `bridge.py` | Cloud printing via Docker bridge, credential loading, AMS tray mapping, printer status | Archive construction, settings generation, slicer invocation |
+| `bridge.py` | Cloud printing via the bridge (Rust `bambox-bridge` local binary or Docker image), credential loading, AMS tray mapping, printer status. **Currently straddles legacy C++ `estampo/cloud-bridge` image and the new Rust `bambox-bridge` — see ADR-002. Do not add logic that entrenches the C++ path.** | Archive construction, settings generation, slicer invocation |
 | `cli.py` | Typer commands (pack, print, status), argument parsing, user-facing output | Business logic — delegate to pack/bridge/settings |
 | `cura.py` | CuraEngine Docker invocation, profile conversion, start/end G-code injection | OrcaSlicer logic, archive packing, printer communication |
 | `templates.py` | OrcaSlicer→Jinja2 syntax conversion, template rendering | G-code generation, settings logic |
@@ -56,10 +56,22 @@ Bambu printers require a `project_settings.config` with ~544 keys in the .gcode.
 
 Do NOT modify `fixup_project_settings()` without understanding the array padding and key fixup logic — it ensures Bambu Connect firmware acceptance.
 
-### Docker Bridge Pattern
-Cloud printing wraps `estampo/cloud-bridge:bambu-*` Docker image. Two modes:
+### Bridge Architecture (migration in progress — see ADR-002)
+
+Cloud printing goes through a "bridge" binary that wraps `libbambu_networking.so`. There are **two bridges in the tree** and the codebase is mid-migration between them:
+
+1. **Rust `bambox-bridge`** (target) — source in `bridge/`, Docker image `bambox/bridge` built from `bridge/Dockerfile`. Implements `status`, `watch`, `daemon` subcommands; credentials via global `-c/--credentials` flag. `_find_local_bridge()` picks it up when installed locally.
+2. **Legacy C++ `estampo/cloud-bridge:bambu-*`** (deprecated) — still referenced in `bridge.py` as the Docker fallback. Positional `status <device> <token>` / `print` / `cancel` CLI. Will be removed once the Rust bridge reaches parity.
+
+The two bridges are **not CLI-compatible**. Do not assume args that work against one will work against the other. When touching `bridge.py`, route subcommands explicitly based on which bridge is being invoked.
+
+Docker invocation currently supports two modes for the legacy image:
 1. **Bind-mount** (primary) — mounts .gcode.3mf via `-v`
 2. **Baked fallback** — for sandboxed/DinD environments, builds temp image with COPY
+
+Both fallback modes exist because of the C++ bridge. The Rust bridge's HTTP daemon API is designed to eliminate them — do not extend these code paths; drive the migration forward instead.
+
+**Full migration plan:** `docs/bridge-migration-plan.md`. **Decision record:** `docs/decisions/002-rust-bridge-replaces-cpp.md`.
 
 ### Bambu Connect Compatibility
 The archive format is validated by printer firmware. Key constraints:
@@ -70,7 +82,7 @@ The archive format is validated by printer firmware. Key constraints:
 ## What bambox is NOT
 
 - **Not a slicer.** It packages G-code produced by slicers. The CuraEngine integration in `cura.py` invokes an external engine — it does not implement slicing.
-- **Not a printer API client.** It wraps the Docker bridge for cloud printing. The actual protocol implementation lives in the bridge binary (C++ today, Rust planned).
+- **Not a printer API client.** It wraps the bridge binary for cloud printing. The actual protocol implementation lives in `bridge/` (Rust, calling `libbambu_networking.so` via FFI). The legacy C++ bridge is being phased out — see ADR-002.
 - **Not estampo.** estampo is the pipeline orchestrator. bambox is the Bambu Lab packaging library that estampo depends on. Do not add pipeline, DAG, or orchestration logic here.
 - **Not a profile editor.** It loads and overlays profiles. Do not build profile editing or merging UI.
 
@@ -81,4 +93,4 @@ bambox is one piece of a three-project architecture:
 - **bambox** — BBL .gcode.3mf packaging + G-code templates + settings generation
 - **bambu-cloud** (planned) — printer communication
 
-Per estampo ADR-005, bambox will absorb printer code from estampo at v0.4.0. See `docs/bridge-migration-plan.md` for the Rust bridge migration plan.
+Per estampo ADR-005, bambox will absorb printer code from estampo at v0.4.0. See `docs/bridge-migration-plan.md` for the full Rust bridge migration plan and `docs/decisions/002-rust-bridge-replaces-cpp.md` for the decision record.

--- a/changes/+bridge-migration-intent.misc
+++ b/changes/+bridge-migration-intent.misc
@@ -1,0 +1,1 @@
+Document Rust `bambox-bridge` as the replacement for the legacy C++ `estampo/cloud-bridge`: restore the bridge migration plan, add ADR-002, and update CLAUDE.md.

--- a/docs/bridge-migration-plan.md
+++ b/docs/bridge-migration-plan.md
@@ -1,0 +1,272 @@
+# Bridge Migration Plan
+
+This plan supersedes `daemon-bridge-design.md`. The original design proposed a
+Python HTTP wrapper around the C++ bridge binary. This plan replaces both the
+C++ binary and the Python wrapper with a single Rust binary that calls
+`libbambu_networking.so` via FFI and exposes an HTTP API.
+
+It also covers migrating all printer-specific code from estampo into bambu-3mf,
+making estampo a pure G-code generation tool.
+
+## Architecture
+
+```
+estampo (Python)                    bambu-3mf (Python + Rust)
+┌──────────────┐                   ┌─────────────────────────────────┐
+│ STL → G-code │──── .gcode ────▶  │ pack (gcode_compat + 3MF)      │
+│              │                   │ auth (Bambu Cloud OAuth)        │
+│ OrcaSlicer   │                   │ credentials (printer config)    │
+│ CuraEngine   │                   │ bridge client (HTTP)            │
+│ PrusaSlicer  │                   │ AMS mapping                     │
+└──────────────┘                   └───────────┬─────────────────────┘
+                                               │ HTTP
+                                   ┌───────────▼─────────────────────┐
+                                   │ bambu-bridge (Rust binary)      │
+                                   │                                 │
+                                   │  axum HTTP API (:8765)          │
+                                   │  ├── GET  /health               │
+                                   │  ├── GET  /status/:device       │
+                                   │  ├── GET  /ams/:device          │
+                                   │  ├── POST /print                │
+                                   │  ├── POST /cancel/:device       │
+                                   │  └── WS   /watch/:device        │
+                                   │                                 │
+                                   │  FFI → shim.cpp → .so           │
+                                   │  Persistent MQTT connection     │
+                                   │  Cached printer state           │
+                                   └─────────────────────────────────┘
+```
+
+## Phase 1: Rust bridge daemon (status + watch)
+
+**Goal:** Replace `bambu_cloud_bridge.cpp` with a Rust binary that can
+authenticate, connect to MQTT, and stream printer status.
+
+**Scope:** `status` and `watch` subcommands only. No printing, no HTTP API yet.
+CLI tool matching the C++ bridge interface for drop-in testing.
+
+### Components
+
+```
+bambu-3mf/
+└── bridge/
+    ├── Cargo.toml
+    ├── build.rs              # cc crate compiles shim.cpp
+    ├── src/
+    │   ├── main.rs           # CLI: status, watch subcommands
+    │   ├── agent.rs          # BambuAgent: init, connect, subscribe
+    │   ├── ffi.rs            # Raw FFI bindings (extern "C" types)
+    │   └── callbacks.rs      # Rust callback handlers
+    └── shim/
+        └── shim.cpp          # extern "C" wrappers for .so functions
+```
+
+### C++ shim (~200 LOC)
+
+The `.so` exports functions using C++ types (`std::string`, `std::function`,
+`std::map`). The shim wraps each function with `extern "C"` using C-compatible
+types:
+
+```cpp
+// shim.cpp — compiled by build.rs via cc crate
+extern "C" {
+    void* bambu_shim_create_agent(const char* log_dir);
+    int   bambu_shim_connect_server(void* agent);
+    int   bambu_shim_change_user(void* agent, const char* user_json);
+    int   bambu_shim_send_message(void* agent, const char* dev_id,
+                                  const char* json, int qos);
+    int   bambu_shim_set_on_message_fn(void* agent,
+              void (*cb)(const char* dev_id, const char* msg, void* ctx),
+              void* ctx);
+    // ... ~15 functions total
+}
+```
+
+### Rust FFI (~100 LOC)
+
+```rust
+// ffi.rs
+extern "C" {
+    fn bambu_shim_create_agent(log_dir: *const c_char) -> *mut c_void;
+    fn bambu_shim_connect_server(agent: *mut c_void) -> c_int;
+    fn bambu_shim_change_user(agent: *mut c_void, json: *const c_char) -> c_int;
+    fn bambu_shim_set_on_message_fn(
+        agent: *mut c_void,
+        cb: extern "C" fn(*const c_char, *const c_char, *mut c_void),
+        ctx: *mut c_void,
+    ) -> c_int;
+    // ...
+}
+```
+
+### Deliverables
+
+- [ ] `shim.cpp` wrapping the ~15 `.so` functions used by status/watch
+- [ ] `build.rs` compiling the shim and linking `libdl`
+- [ ] `BambuAgent` struct managing agent lifecycle
+- [ ] `status` subcommand: connect, subscribe, pushall, print JSON, exit
+- [ ] `watch` subcommand: connect, subscribe, stream MQTT messages to stdout
+- [ ] Credential loading from `~/.config/estampo/credentials.toml`
+- [ ] Test against real printer (P1S workshop)
+
+## Phase 2: HTTP API
+
+**Goal:** Add an axum HTTP server so Python clients can talk to the bridge
+over HTTP instead of stdin/stdout.
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/health` | Daemon health + MQTT connection state |
+| GET | `/status/{device_id}` | Cached printer status (instant) |
+| GET | `/ams/{device_id}` | AMS tray info from cached status |
+| POST | `/print` | Upload 3MF + start print job |
+| POST | `/cancel/{device_id}` | Cancel current print |
+| WS | `/watch/{device_id}` | Live status stream via WebSocket |
+
+### Key design decisions
+
+- **Files via HTTP POST, not filesystem.** 3MF uploaded in request body.
+  Eliminates bind-mount issues in DinD, sandboxed, and remote environments.
+- **MQTT persists across requests.** Status returns cached data, no 20s wait.
+- **Credentials at startup.** Token JSON passed once via `--credentials` flag
+  or `BAMBU_CREDENTIALS` env var.
+- **Localhost only.** Binds to `127.0.0.1:8765`. No auth needed.
+
+### Dependencies
+
+```toml
+[dependencies]
+axum = "0.8"
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+clap = { version = "4", features = ["derive"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
+```
+
+## Phase 3: Migrate printer code from estampo
+
+**Goal:** Move all Bambu-specific code from estampo into bambu-3mf. estampo
+becomes a pure slicing tool (STL → G-code).
+
+### Code to move from estampo
+
+| Source (estampo) | Destination (bambu-3mf) | Description |
+|------------------|------------------------|-------------|
+| `src/estampo/cloud/bridge.py` | `src/bambu_3mf/bridge.py` | Bridge wrapper (rewritten as HTTP client) |
+| `src/estampo/cloud/ams.py` | `src/bambu_3mf/ams.py` | AMS tray parsing + mapping |
+| `src/estampo/auth.py` | `src/bambu_3mf/auth.py` | Bambu Cloud OAuth login |
+| `src/estampo/credentials.py` | `src/bambu_3mf/credentials.py` | Printer credential management |
+| `src/estampo/printer.py` | `src/bambu_3mf/printer.py` | Print dispatch (cloud, LAN, Moonraker) |
+| `scripts/bambu_cloud_bridge.cpp` | (deleted — replaced by Rust) | C++ bridge binary |
+| `Dockerfile.cloud-bridge` | `bridge/Dockerfile` | Bridge Docker image |
+| `tests/test_cloud.py` | `tests/test_bridge.py` | Bridge + AMS tests |
+| `tests/test_printer.py` | `tests/test_printer.py` | Print dispatch tests |
+| `tests/test_credentials.py` | `tests/test_credentials.py` | Credential tests |
+| `tests/test_auth.py` | `tests/test_auth.py` | Auth tests |
+
+### Code to remove from estampo
+
+| File | Action |
+|------|--------|
+| `src/estampo/cloud/` | Delete entire directory |
+| `src/estampo/auth.py` | Delete |
+| `src/estampo/credentials.py` | Delete |
+| `src/estampo/printer.py` | Delete |
+| `scripts/bambu_cloud_bridge.cpp` | Delete |
+| `scripts/bambu_cloud_login.py` | Delete |
+| `scripts/test_cloud_print.py` | Delete |
+| `Dockerfile.cloud-bridge` | Delete |
+| CLI: `status` command | Remove |
+| CLI: `--upload-only` flag | Remove |
+| Pipeline: `print_result` node | Remove |
+| `config.py`: `[printer]` section | Remove |
+| `init.py`: printer wizard steps | Remove |
+
+### Code to keep in estampo
+
+| File | Description |
+|------|-------------|
+| `slicer.py` | OrcaSlicer Docker execution |
+| `cura.py` | CuraEngine execution |
+| `pipeline.py` | Slicing pipeline (STL → G-code only) |
+| `config.py` | Slicer config (`[slicer]` section only) |
+| `init.py` | Profile setup wizard (slicer profiles only) |
+| `cli.py` | `run` (slice only) and `init` commands |
+| `profiles.py` | Slicer profile management |
+
+### bambu-3mf CLI
+
+After migration, bambu-3mf gets its own CLI for printing:
+
+```bash
+# Bridge daemon
+bambu-3mf daemon start
+bambu-3mf daemon stop
+bambu-3mf daemon status
+
+# Printing
+bambu-3mf print file.gcode --printer workshop
+bambu-3mf status --printer workshop --watch
+bambu-3mf cancel --printer workshop
+
+# Setup
+bambu-3mf login
+bambu-3mf add-printer
+```
+
+### Migration strategy
+
+1. Copy code into bambu-3mf, adapt imports, get tests passing
+2. bambu-3mf publishes a release with the new modules
+3. estampo drops its printer code, adds optional `bambu-3mf` dependency
+4. estampo CLI can offer a convenience `print` that delegates to bambu-3mf
+
+## Phase 4: Docker packaging
+
+**Goal:** Ship the Rust bridge daemon in a Docker image for users who don't
+want to install the `.so` and cert locally.
+
+```dockerfile
+FROM debian:bookworm-slim
+COPY libbambu_networking.so /usr/lib/
+COPY slicer_base64.cer /etc/bambu/cert/
+COPY bambu-bridge /usr/local/bin/
+EXPOSE 8765
+ENTRYPOINT ["bambu-bridge", "daemon"]
+```
+
+Final image: ~20MB (Rust static binary + `.so` + cert + minimal base).
+
+Users run:
+```bash
+docker run -d --name bambu-bridge \
+  -p 8765:8765 \
+  -e BAMBU_CREDENTIALS='{"token":"..."}' \
+  estampo/bambu-bridge:latest
+```
+
+## Timeline
+
+| Phase | Scope | Depends on |
+|-------|-------|------------|
+| 1 | Rust CLI: status + watch | Nothing |
+| 2 | HTTP API (axum) | Phase 1 |
+| 3 | Migrate printer code from estampo | Phase 2 |
+| 4 | Docker image | Phase 2 |
+
+Phases 1-2 are the critical path. Phase 3 can happen in parallel once the
+bridge HTTP API is stable. Phase 4 is packaging.
+
+## Open questions
+
+1. **Moonraker support** — Move to bambu-3mf or drop? It's not Bambu-specific
+   but it is printer-specific. Could become a separate `moonraker-print` package
+   or stay in bambu-3mf as a generic printer backend.
+2. **LAN printing** — Currently uses `bambulabs_api` Python package. Move as-is
+   or rewrite in Rust alongside cloud printing?
+3. **Credential storage** — Keep `~/.config/estampo/credentials.toml` or move
+   to `~/.config/bambu-3mf/`? Or support both with a migration path?

--- a/docs/decisions/002-rust-bridge-replaces-cpp.md
+++ b/docs/decisions/002-rust-bridge-replaces-cpp.md
@@ -1,0 +1,152 @@
+# ADR-002: Rust `bambox-bridge` Replaces C++ `estampo/cloud-bridge`
+
+**Status:** Accepted (migration in progress)
+**Date:** 2026-04-11
+**Supersedes:** `docs/daemon-bridge-design.md` (Python-HTTP-over-C++ design)
+**Tracking issue:** TBD
+
+## Context
+
+bambox communicates with Bambu Lab cloud printers through a "bridge" — a
+binary that loads `libbambu_networking.so`, authenticates with Bambu Cloud,
+subscribes to the printer's MQTT topics, and handles status queries and
+print dispatch.
+
+Two bridge implementations currently exist in this repository, and the
+project is mid-migration between them:
+
+1. **Legacy C++ bridge.** Distributed as the Docker image
+   `estampo/cloud-bridge:bambu-02.05.00.00`. Built from
+   `scripts/bambu_cloud_bridge.cpp` in the estampo repository. Subcommands
+   `status`, `print`, `cancel` with the credentials token passed as a
+   positional argument. This is what `src/bambox/bridge.py:34` currently
+   targets.
+2. **Rust `bambox-bridge`.** Source in `bridge/` in this repository. Calls
+   `libbambu_networking.so` via a thin C++ shim (`shim/shim.cpp`) and FFI.
+   Implements `status`, `watch`, and `daemon` subcommands today. Credentials
+   are passed via a global `-c/--credentials` flag. A Docker image
+   (`bambox/bridge`) is built from `bridge/Dockerfile` but nothing in Python
+   references it yet.
+
+Phase 1 and Phase 2 of the migration (Rust binary + HTTP API skeleton) were
+implemented on top of the plan in `docs/bridge-migration-plan.md`. The plan
+originated on branch `plan/bridge-migration` (commit `434b73c`) but was
+never merged to main, so for a period the Rust bridge existed without any
+merged documentation of intent. This ADR closes that gap.
+
+The immediate trigger for writing this ADR: a user installed the Rust
+`bambox-bridge` locally, `_find_local_bridge()` in `bridge.py` picked it up,
+and `bambox status` crashed because Python passed the token file
+positionally (the C++ CLI shape) while the Rust CLI expects `-c`. The two
+bridges are not drop-in compatible, and nothing in the codebase made that
+obvious.
+
+## Decision
+
+**The Rust `bambox-bridge` is the only bridge. The C++ bridge is deprecated
+and will be removed.**
+
+Concretely:
+
+1. `bambox-bridge` (Rust, in `bridge/`) is the single source of truth for
+   Bambu cloud communication going forward. All new bridge functionality
+   lands in the Rust crate.
+2. The Python client (`src/bambox/bridge.py`) will stop referencing
+   `estampo/cloud-bridge`. The Docker fallback path will target the Rust
+   `bambox/bridge` image built from `bridge/Dockerfile`.
+3. The Python↔bridge transport unifies: Python calls `bambox-bridge` with a
+   single CLI contract regardless of whether the binary runs locally or
+   inside Docker. Long term, Python talks to the bridge over the HTTP
+   daemon API (`axum`, port 8765) rather than stdout JSON — this
+   eliminates the bind-mount/baked-image fallback dance and the 20-second
+   MQTT-per-call cost.
+4. The Rust bridge must reach CLI parity with what Python expects before
+   the C++ image can be deleted: `Print` and `Cancel` subcommands must be
+   added to `bridge/src/main.rs`.
+5. Until parity is reached, `_run_bridge_local()` must not claim coverage
+   it doesn't have — it should only take over for subcommands the Rust
+   bridge actually implements, and fall through to the legacy Docker path
+   for the rest. This is the stopgap, not the destination.
+6. Phase 3 of the migration plan (absorbing estampo's printer code into
+   bambox) continues to target v0.4.0, per the existing roadmap.
+
+The full implementation plan — including the FFI shim design, HTTP API
+endpoints, module-by-module move from estampo, and Docker packaging — lives
+in `docs/bridge-migration-plan.md`. This ADR records the decision; the plan
+records the mechanics.
+
+## Consequences
+
+### Benefits
+
+- **One bridge, one CLI contract.** Eliminates the class of bug that
+  triggered this ADR: Python can no longer silently route to a bridge with
+  an incompatible CLI.
+- **No bind-mount gymnastics.** Uploading 3MFs over HTTP removes the baked-
+  Docker-image fallback in `_run_bridge_baked()` and all the sandbox
+  workarounds around it.
+- **Persistent MQTT connection.** Status queries return cached state
+  instantly instead of paying a ~20s MQTT connect+subscribe cost per call.
+- **Memory-safe bridge.** The C++ binary is replaced by a Rust binary that
+  wraps the `.so` behind a narrow FFI surface.
+- **Self-contained repo.** The bridge source lives in bambox, not in
+  estampo. estampo becomes a pure slicing tool.
+
+### Costs
+
+- **Rust toolchain in CI.** The bridge build already requires this — the
+  Dockerfile uses `rust:1.88-bookworm`. Contributors touching the bridge
+  need Rust installed locally.
+- **FFI fragility.** The `.so` exports C++ types; the shim wraps each
+  function in `extern "C"`. ABI drift in a future Bambu Studio release
+  could break the shim. This risk existed with the C++ bridge too.
+- **Migration window.** Until `Print` and `Cancel` land in the Rust bridge,
+  the legacy C++ image remains in the tree and `_run_bridge_local()` has
+  to be selective about what it handles. This is a known transitional
+  hazard.
+- **Print/cancel parity gap.** The Rust bridge currently only implements
+  `status`, `watch`, `daemon`. Closing this gap is the critical-path work
+  for removing the C++ image.
+
+### Non-goals
+
+- This ADR does not decide between "Python shells out to `bambox-bridge`
+  CLI" and "Python talks to the bridge HTTP daemon." The destination is
+  HTTP (per the migration plan), but the CLI path remains supported for
+  one-shot invocations and tests.
+- This ADR does not cover LAN printing or Moonraker. Those are tracked
+  separately (issue #91 for LAN) and are out of scope for the C++→Rust
+  migration.
+
+## Alternatives considered
+
+### Keep the C++ bridge, wrap it in a Python HTTP daemon
+
+This was the original design in `docs/daemon-bridge-design.md`. Rejected
+because it leaves two languages in the critical path (C++ binary + Python
+HTTP wrapper) and doesn't address the bind-mount issues — it just moves
+them into the daemon container.
+
+### Rewrite Python `bridge.py` to match the C++ CLI more faithfully and drop the Rust work
+
+Rejected. The C++ binary depends on estampo's build system, is hard to
+distribute (no static binary, no Homebrew tap), and carries the bind-mount
+failure modes that motivated the migration in the first place. The Rust
+work is already past Phase 2; throwing it away would cost more than
+finishing it.
+
+### Keep both bridges long-term, select by config
+
+Rejected. Two CLI contracts, two test matrices, two release pipelines.
+The bug that triggered this ADR is exactly what happens when "two bridges
+coexist" meets reality.
+
+## References
+
+- `docs/bridge-migration-plan.md` — full 4-phase implementation plan
+- Plan commit: `434b73c` (branch `plan/bridge-migration`, unmerged until
+  this ADR)
+- `bridge/src/main.rs` — Rust bridge entry point
+- `bridge/Dockerfile` — Rust bridge Docker image (`bambox/bridge`)
+- `src/bambox/bridge.py` — Python client (currently straddles both bridges)
+- estampo ADR-005 — v0.4.0 printer-code absorption

--- a/docs/decisions/002-rust-bridge-replaces-cpp.md
+++ b/docs/decisions/002-rust-bridge-replaces-cpp.md
@@ -3,7 +3,7 @@
 **Status:** Accepted (migration in progress)
 **Date:** 2026-04-11
 **Supersedes:** `docs/daemon-bridge-design.md` (Python-HTTP-over-C++ design)
-**Tracking issue:** TBD
+**Tracking issue:** estampo/bambox#143
 
 ## Context
 


### PR DESCRIPTION
## Summary

- Restores `docs/bridge-migration-plan.md` from the orphaned `plan/bridge-migration` branch (commit 434b73c) — the plan was written but never merged, which is how we ended up with a Rust bridge in `bridge/` and Python still pointed at the legacy C++ image.
- Adds **ADR-002**: Rust `bambox-bridge` replaces C++ `estampo/cloud-bridge`. Records the decision, the current mid-migration hazard, and the non-goals.
- Updates **CLAUDE.md**: rewrites the Docker Bridge Pattern section, flags `bridge.py` as straddling both bridges in the Module Ownership table, fixes the dangling reference to the migration plan.

No code changes. Implementation work is tracked in #143.

## Context

A user installed the Rust `bambox-bridge` locally, `_find_local_bridge()` picked it up, and `bambox status` crashed because Python passed the token file positionally (C++ CLI shape) while the Rust CLI expects \`-c\`. The two bridges are not drop-in compatible and nothing in the merged codebase made that obvious. This PR closes the documentation gap; the actual code fix is tracked separately in #143.

## Test plan

- [ ] \`uv run ruff check src tests\` — passes
- [ ] \`uv run ruff format --check src tests\` — passes
- [ ] \`uv run mypy src/bambox\` — passes
- [ ] \`uv run pytest\` — passes
- [ ] Review ADR-002 wording for accuracy (esp. the "non-goals" section — ok to leave the CLI-vs-HTTP choice open?)
- [ ] Confirm restoring \`docs/bridge-migration-plan.md\` verbatim is preferred over folding it into ADR-002

Related: #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)