### PR TITLE
Shrink bridge Docker image from 174MB to 60MB

### DIFF
--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -40,40 +40,31 @@ COPY build.rs ./
 RUN cargo build --release
 
 # ---------------------------------------------------------------------------
-# Runtime stage: minimal image with the binary and libbambu_networking.so
+# Fetch stage: download libbambu_networking.so and slicer cert
 # ---------------------------------------------------------------------------
-FROM --platform=linux/amd64 debian:bookworm-slim
-
-LABEL org.opencontainers.image.description="bambox bridge daemon — Bambu Lab printer communication via HTTP API"
+FROM --platform=linux/amd64 debian:bookworm-slim AS fetcher
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libssl3 \
-    ca-certificates \
-    curl \
-    python3 \
-    unzip \
+    curl python3 unzip ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 # Fetch libbambu_networking.so — try Bambu's API first, fall back to private cache.
-# The API returns a signed CDN URL for the current Linux plugin zip.
-# If Bambu's API/CDN is unavailable, fetch from a private GitHub release.
 ARG BAMBU_SLICER_VERSION=02.05.00.00
 ARG BNL_TOKEN=""
-RUN mkdir -p /tmp/bambu_plugin \
+RUN mkdir -p /out/lib /out/cert \
     && (PLUGIN_URL=$(curl -fsSL \
         -H "User-Agent: BambuStudio/${BAMBU_SLICER_VERSION}" \
         -H "X-BBL-OS-Type: linux" \
         "https://api.bambulab.com/v1/iot-service/api/slicer/resource?slicer/plugins/cloud=${BAMBU_SLICER_VERSION}" \
         | python3 -c "import sys,json; r=json.load(sys.stdin)['resources']; print([x for x in r if 'plugins' in x['type']][0]['url'])") \
     && curl -fsSL -o /tmp/plugins.zip "$PLUGIN_URL" \
-    && unzip -j /tmp/plugins.zip libbambu_networking.so -d /tmp/bambu_plugin/ \
-    && rm /tmp/plugins.zip \
+    && unzip -j /tmp/plugins.zip libbambu_networking.so -d /out/lib/ \
     && echo "Fetched libbambu_networking.so from Bambu API") \
     || (echo "Bambu API failed, falling back to private cache..." \
     && curl -fsSL \
         -H "Authorization: token ${BNL_TOKEN}" \
         -H "Accept: application/octet-stream" \
-        -o /tmp/bambu_plugin/libbambu_networking.so \
+        -o /out/lib/libbambu_networking.so \
         "https://api.github.com/repos/estampo/bnl/releases/assets/$(curl -fsSL \
             -H "Authorization: token ${BNL_TOKEN}" \
             "https://api.github.com/repos/estampo/bnl/releases/tags/v${BAMBU_SLICER_VERSION}" \
@@ -81,13 +72,22 @@ RUN mkdir -p /tmp/bambu_plugin \
     && echo "Fetched libbambu_networking.so from private cache")
 
 # Download slicer TLS certificate (for MQTT to *.bambulab.com)
-RUN mkdir -p /tmp/bambu_agent/cert /tmp/bambu_agent/log /tmp/bambu_agent/config \
-    && curl -fSL -o /tmp/bambu_agent/cert/slicer_base64.cer \
+RUN curl -fSL -o /out/cert/slicer_base64.cer \
        "https://raw.githubusercontent.com/bambulab/BambuStudio/master/resources/cert/slicer_base64.cer"
 
+# ---------------------------------------------------------------------------
+# Runtime stage: binary + .so + cert on distroless (glibc + libssl, no shell)
+# ---------------------------------------------------------------------------
+FROM --platform=linux/amd64 gcr.io/distroless/cc-debian12
+
+LABEL org.opencontainers.image.description="bambox bridge daemon — Bambu Lab printer communication via HTTP API"
+
+COPY --from=fetcher /out/lib/libbambu_networking.so /usr/lib/libbambu_networking.so
+COPY --from=fetcher /out/cert/slicer_base64.cer /tmp/bambu_agent/cert/slicer_base64.cer
+COPY --from=fetcher /lib/x86_64-linux-gnu/liblzma.so.5 /usr/lib/x86_64-linux-gnu/liblzma.so.5
 COPY --from=builder /build/target/release/bambox-bridge /usr/local/bin/bambox-bridge
 
-ENV BAMBU_LIB_PATH=/tmp/bambu_plugin/libbambu_networking.so
+ENV BAMBU_LIB_PATH=/usr/lib/libbambu_networking.so
 
 EXPOSE 8765
 

--- a/changes/+docker-slim.misc
+++ b/changes/+docker-slim.misc
@@ -1,0 +1,1 @@
+Shrink bridge Docker image from 174MB to 60MB using distroless base and multi-stage fetch.


### PR DESCRIPTION
## Summary
- Move `.so` and cert fetching into a dedicated `fetcher` build stage (python3/curl/unzip don't end up in the final image)
- Switch runtime base from `debian:bookworm-slim` (~135MB) to `gcr.io/distroless/cc-debian12` (~46MB)
- Copy only `liblzma.so.5` from the fetcher stage (the one missing library)
- Final image: binary (10MB) + .so (4.5MB) + distroless base (46MB) = **60MB**

## Test plan
- [x] `docker build` succeeds
- [x] `docker run --rm bambox-bridge-distroless --help` works
- [x] Binary loads `.so` and shows all subcommands (status, print, cancel, watch, daemon)
- [ ] End-to-end test with real printer (needs credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)