### PR TITLE
Fix Docker bridge: add libz.so.1, restore COPY fallback

### DIFF
--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -85,6 +85,7 @@ LABEL org.opencontainers.image.description="bambox bridge daemon — Bambu Lab p
 COPY --from=fetcher /out/lib/libbambu_networking.so /usr/lib/libbambu_networking.so
 COPY --from=fetcher /out/cert/slicer_base64.cer /tmp/bambu_agent/cert/slicer_base64.cer
 COPY --from=fetcher /lib/x86_64-linux-gnu/liblzma.so.5 /usr/lib/x86_64-linux-gnu/liblzma.so.5
+COPY --from=fetcher /lib/x86_64-linux-gnu/libz.so.1 /usr/lib/x86_64-linux-gnu/libz.so.1
 COPY --from=builder /build/target/release/bambox-bridge /usr/local/bin/bambox-bridge
 
 ENV BAMBU_LIB_PATH=/usr/lib/libbambu_networking.so

--- a/src/bambox/bridge.py
+++ b/src/bambox/bridge.py
@@ -155,9 +155,13 @@ def _run_bridge_docker(
     timeout: int = 300,
     verbose: bool = False,
 ) -> subprocess.CompletedProcess[str]:
-    """Run the cloud bridge via Docker with bind-mount mode.
+    """Run the cloud bridge via Docker.
 
-    Volume-mounts any local file paths into the container.
+    Tries bind-mount mode first (``-v host:container``).  If the container
+    reports that a mounted file cannot be read (common in Docker-in-Docker
+    or overlay-filesystem environments where file bind-mounts appear as
+    directories), falls back to building a one-shot image that ``COPY``s the
+    files in.
     """
     install_hint = (
         "Install the bridge: curl -fsSL "
@@ -180,6 +184,8 @@ def _run_bridge_docker(
         timeout=120,
     )
 
+    # Collect local file paths for potential COPY fallback
+    file_args: dict[str, str] = {}  # host_path -> container_path
     cmd: list[str] = ["docker", "run", "--rm", "--platform", "linux/amd64"]
     docker_args: list[str] = []
     for arg in args:
@@ -189,6 +195,7 @@ def _run_bridge_docker(
             container_path = f"/input/{basename}"
             cmd.extend(["-v", f"{real}:{container_path}:ro"])
             docker_args.append(container_path)
+            file_args[real] = container_path
         else:
             docker_args.append(arg)
 
@@ -197,8 +204,64 @@ def _run_bridge_docker(
     if verbose:
         cmd.append("-v")
 
-    log.debug("Running (docker): %s", " ".join(cmd))
-    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    log.debug("Running (docker bind-mount): %s", " ".join(cmd))
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+
+    if result.returncode != 0 and file_args and "cannot read" in result.stderr:
+        log.info("Bind-mount failed, falling back to COPY-based Docker run")
+        return _run_bridge_docker_copy(args, file_args, timeout=timeout, verbose=verbose)
+
+    return result
+
+
+def _run_bridge_docker_copy(
+    args: list[str],
+    file_args: dict[str, str],
+    *,
+    timeout: int = 300,
+    verbose: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    """Fallback: build a one-shot image that COPYs files instead of bind-mounting."""
+    import shutil
+
+    tmpdir = Path(tempfile.mkdtemp(prefix="bambu_bridge_"))
+    try:
+        lines = [f"FROM {DOCKER_IMAGE}"]
+        for host_path, container_path in file_args.items():
+            basename = os.path.basename(host_path)
+            shutil.copy2(host_path, tmpdir / basename)
+            lines.append(f"COPY {basename} {container_path}")
+        (tmpdir / "Dockerfile").write_text("\n".join(lines) + "\n")
+
+        tag = "bambox-bridge-tmp"
+        build = subprocess.run(
+            ["docker", "build", "-t", tag, "."],
+            capture_output=True,
+            text=True,
+            cwd=str(tmpdir),
+            timeout=60,
+        )
+        if build.returncode != 0:
+            raise RuntimeError(f"Docker build failed: {build.stderr[:500]}")
+
+        docker_args: list[str] = []
+        for arg in args:
+            real = os.path.realpath(arg) if os.path.exists(arg) else ""
+            if real in file_args:
+                docker_args.append(file_args[real])
+            else:
+                docker_args.append(arg)
+
+        cmd = ["docker", "run", "--rm", "--platform", "linux/amd64", tag]
+        cmd.extend(docker_args)
+        if verbose:
+            cmd.append("-v")
+
+        log.debug("Running (docker copy): %s", " ".join(cmd))
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+        subprocess.run(["docker", "rmi", tag], capture_output=True, timeout=10)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bridge_docker.py
+++ b/tests/test_bridge_docker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -10,6 +11,7 @@ import pytest
 from bambox.bridge import (
     DOCKER_IMAGE,
     _run_bridge_docker,
+    _run_bridge_docker_copy,
 )
 
 # -- _run_bridge_docker --------------------------------------------------------
@@ -32,11 +34,10 @@ class TestRunBridgeDocker:
     def test_bind_mount_basic_args(self):
         """Non-file args should be passed through without -v mounts."""
         with patch("bambox.bridge.subprocess.run") as mock_run:
-            # docker info → docker pull → docker run
             mock_run.side_effect = [
-                subprocess.CompletedProcess([], 0, "", ""),
-                subprocess.CompletedProcess([], 0, "", ""),
-                subprocess.CompletedProcess([], 0, '{"result":"ok"}', ""),
+                subprocess.CompletedProcess([], 0, "", ""),  # docker info
+                subprocess.CompletedProcess([], 0, "", ""),  # docker pull
+                subprocess.CompletedProcess([], 0, '{"result":"ok"}', ""),  # docker run
             ]
             result = _run_bridge_docker(["-c", "/tmp/token.json", "status", "DEV1"])
 
@@ -85,7 +86,6 @@ class TestRunBridgeDocker:
 
             docker_run_call = mock_run.call_args_list[2]
             cmd = docker_run_call[0][0]
-            # Should have -v flags for both files
             v_indices = [i for i, c in enumerate(cmd) if c == "-v"]
             assert len(v_indices) >= 2
             mounts = [cmd[i + 1] for i in v_indices]
@@ -102,7 +102,6 @@ class TestRunBridgeDocker:
             _run_bridge_docker(["status", "DEV1"], verbose=True)
 
             cmd = mock_run.call_args_list[2][0][0]
-            # -v should appear after the image name (as bridge arg, not docker arg)
             image_idx = cmd.index(DOCKER_IMAGE)
             tail = cmd[image_idx + 1 :]
             assert "-v" in tail
@@ -110,3 +109,134 @@ class TestRunBridgeDocker:
     def test_docker_image_is_rust_bridge(self):
         """DOCKER_IMAGE should point to the Rust bambox-bridge image."""
         assert DOCKER_IMAGE == "estampo/bambox-bridge:bambu-02.05.00.00"
+
+    def test_bind_mount_failure_triggers_copy_fallback(self, tmp_path):
+        """'cannot read' in stderr should trigger COPY fallback."""
+        test_file = tmp_path / "test.3mf"
+        test_file.write_text("fake 3mf")
+
+        with (
+            patch("bambox.bridge.subprocess.run") as mock_run,
+            patch("bambox.bridge._run_bridge_docker_copy") as mock_copy,
+        ):
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, "", ""),  # docker info
+                subprocess.CompletedProcess([], 0, "", ""),  # docker pull
+                subprocess.CompletedProcess(
+                    [], 1, "", "cannot read /input/test.3mf: Is a directory"
+                ),
+            ]
+            mock_copy.return_value = subprocess.CompletedProcess([], 0, '{"result":"ok"}', "")
+
+            _run_bridge_docker(["-c", str(test_file), "print", str(test_file), "DEV1"])
+            mock_copy.assert_called_once()
+
+    def test_non_read_error_returns_without_fallback(self, tmp_path):
+        """Errors that aren't 'cannot read' should NOT trigger fallback."""
+        test_file = tmp_path / "test.3mf"
+        test_file.write_text("fake 3mf")
+
+        with (
+            patch("bambox.bridge.subprocess.run") as mock_run,
+            patch("bambox.bridge._run_bridge_docker_copy") as mock_copy,
+        ):
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, "", ""),  # docker info
+                subprocess.CompletedProcess([], 0, "", ""),  # docker pull
+                subprocess.CompletedProcess([], 1, "", "some other error"),
+            ]
+            result = _run_bridge_docker(["-c", str(test_file), "print", str(test_file), "DEV1"])
+            mock_copy.assert_not_called()
+            assert result.returncode == 1
+
+    def test_no_file_args_skips_fallback(self):
+        """Failure without file args should NOT attempt fallback."""
+        with (
+            patch("bambox.bridge.subprocess.run") as mock_run,
+            patch("bambox.bridge._run_bridge_docker_copy") as mock_copy,
+        ):
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, "", ""),  # docker info
+                subprocess.CompletedProcess([], 0, "", ""),  # docker pull
+                subprocess.CompletedProcess([], 1, "", "cannot read something"),
+            ]
+            result = _run_bridge_docker(["status", "DEV1"])
+            mock_copy.assert_not_called()
+            assert result.returncode == 1
+
+
+# -- _run_bridge_docker_copy ---------------------------------------------------
+
+
+class TestRunBridgeDockerCopy:
+    def test_builds_and_runs_temp_image(self, tmp_path):
+        """Should build a temp Docker image, run it, then clean up."""
+        test_file = tmp_path / "test.3mf"
+        test_file.write_text("fake 3mf content")
+        real_path = str(test_file.resolve())
+
+        file_args = {real_path: "/input/test.3mf"}
+
+        with patch("bambox.bridge.subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, "", ""),  # docker build
+                subprocess.CompletedProcess([], 0, '{"result":"ok"}', ""),  # docker run
+                subprocess.CompletedProcess([], 0, "", ""),  # docker rmi
+            ]
+            result = _run_bridge_docker_copy(
+                ["-c", "/tmp/token.json", "print", str(test_file), "DEV1"],
+                file_args,
+            )
+
+            assert result.returncode == 0
+            build_cmd = mock_run.call_args_list[0][0][0]
+            assert build_cmd[:3] == ["docker", "build", "-t"]
+
+            run_cmd = mock_run.call_args_list[1][0][0]
+            assert run_cmd[0:2] == ["docker", "run"]
+            assert "/input/test.3mf" in run_cmd
+
+            rmi_call = mock_run.call_args_list[2]
+            assert "rmi" in rmi_call[0][0]
+
+    def test_build_failure_raises(self, tmp_path):
+        """Failed docker build should raise RuntimeError."""
+        test_file = tmp_path / "test.3mf"
+        test_file.write_text("fake")
+        real_path = str(test_file.resolve())
+        file_args = {real_path: "/input/test.3mf"}
+
+        with patch("bambox.bridge.subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 1, "", "build error"),  # docker build
+                subprocess.CompletedProcess([], 0, "", ""),  # docker rmi
+            ]
+            with pytest.raises(RuntimeError, match="Docker build failed"):
+                _run_bridge_docker_copy(
+                    ["-c", "/tmp/token.json", "print", str(test_file)], file_args
+                )
+
+    def test_dockerfile_contents(self, tmp_path):
+        """Generated Dockerfile should COPY files from base image."""
+        test_file = tmp_path / "test.3mf"
+        test_file.write_text("fake")
+        real_path = str(test_file.resolve())
+        file_args = {real_path: "/input/test.3mf"}
+
+        dockerfiles_written: list[str] = []
+
+        def capture_dockerfile(cmd, **kwargs):
+            cwd = kwargs.get("cwd", "")
+            if cwd and cmd[:2] == ["docker", "build"]:
+                df = Path(cwd) / "Dockerfile"
+                if df.exists():
+                    dockerfiles_written.append(df.read_text())
+            return subprocess.CompletedProcess([], 0, "", "")
+
+        with patch("bambox.bridge.subprocess.run", side_effect=capture_dockerfile):
+            _run_bridge_docker_copy(["-c", "/tmp/token.json", "print", str(test_file)], file_args)
+
+        assert len(dockerfiles_written) == 1
+        df = dockerfiles_written[0]
+        assert df.startswith(f"FROM {DOCKER_IMAGE}")
+        assert "COPY test.3mf /input/test.3mf" in df


### PR DESCRIPTION
## Summary
- Add missing `libz.so.1` to distroless runtime image — `libbambu_networking.so` needs it
- Restore COPY-based fallback (`_run_bridge_docker_copy`) for environments where file bind-mounts appear as directories (Docker-in-Docker, overlay filesystems)
- Renamed from `_run_bridge_baked` for clarity; same mechanism, cleaner code

## Verified end-to-end
Both paths tested against the live P1S printer:

**Local binary:**
```
$ bambox status -c ~/.config/estampo/credentials.toml 01P00A451601106
  State:    IDLE
  Nozzle:   19°C
  Bed:      17°C
  AMS: slot 1 PLA #FFFFFF, slot 2 ASA #BCBCBC, slot 3 PETG-CF #2850E0, slot 4 PLA #161616
```

**Docker (COPY fallback — this environment can't bind-mount files):**
```
$ bambox status -c ~/.config/estampo/credentials.toml 01P00A451601106
  State:    IDLE    (same output)
```

## Test plan
- [x] 573 tests pass, 48 bridge-specific
- [x] ruff check, ruff format, mypy clean
- [x] Live end-to-end: local binary path
- [x] Live end-to-end: Docker COPY fallback path

## Note
`DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repo secrets need to be added — the publish-docker workflow has been failing since PR #145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)