### PR TITLE
Fix credential files briefly world-readable before chmod

### DIFF
--- a/changes/139.bugfix
+++ b/changes/139.bugfix
@@ -1,0 +1,1 @@
+Fix credentials file briefly world-readable before chmod — now created with 0o600 from the start using ``os.open()``/``mkstemp``, and parent directories use 0o700.

--- a/src/bambox/bridge.py
+++ b/src/bambox/bridge.py
@@ -69,6 +69,9 @@ def load_credentials(path: Path | None = None) -> dict[str, str]:
 def _write_token_json(cloud: dict[str, str], directory: Path | None = None) -> Path:
     """Write a temp JSON token file for the bridge binary.
 
+    Uses ``mkstemp`` + ``fchmod`` so the file is created with 0o600 from the
+    start, avoiding any window where credentials are world-readable.
+
     Returns the path (caller must clean up).
     """
     bridge_data = {
@@ -84,13 +87,16 @@ def _write_token_json(cloud: dict[str, str], directory: Path | None = None) -> P
         from bambox.credentials import _cache_dir
 
         d = _cache_dir()
-    tmp = tempfile.NamedTemporaryFile(
-        mode="w", suffix=".json", prefix="bambu_token_", dir=d, delete=False
-    )
-    json.dump(bridge_data, tmp)
-    tmp.close()
-    Path(tmp.name).chmod(0o600)
-    return Path(tmp.name)
+    fd, path = tempfile.mkstemp(suffix=".json", prefix="bambu_token_", dir=str(d))
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w") as f:
+            json.dump(bridge_data, f)
+    except BaseException:
+        os.close(fd)
+        os.unlink(path)
+        raise
+    return Path(path)
 
 
 # ---------------------------------------------------------------------------

--- a/src/bambox/credentials.py
+++ b/src/bambox/credentials.py
@@ -30,11 +30,11 @@ def _cache_dir() -> Path:
         d = Path.home() / ".cache" / "bambox"
 
     try:
-        d.mkdir(parents=True, exist_ok=True)
+        d.mkdir(parents=True, exist_ok=True, mode=0o700)
         return d
     except OSError:
         fallback = Path(tempfile.gettempdir()) / "bambox"
-        fallback.mkdir(parents=True, exist_ok=True)
+        fallback.mkdir(parents=True, exist_ok=True, mode=0o700)
         log.warning("Cannot create cache dir %s — using %s", d, fallback)
         return fallback
 
@@ -104,28 +104,36 @@ def _quote_toml_key(key: str) -> str:
 def _write_credentials(data: dict) -> None:
     """Write credentials dict to TOML file with 0o600 permissions.
 
-    Manual TOML writer (tomllib is read-only, no tomli_w dependency).
+    Uses ``os.open()`` with explicit mode so the file is never world-readable,
+    even briefly.  Manual TOML writer (tomllib is read-only, no tomli_w
+    dependency).
     """
     path = _credentials_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w") as f:
-        # Write [cloud] section
-        cloud = data.get("cloud", {})
-        if cloud:
-            f.write("[cloud]\n")
-            for key, val in cloud.items():
-                f.write(f'{key} = "{_escape_toml_value(str(val))}"\n')
-            f.write("\n")
-
-        # Write [printers.*] sections
-        for printer_name, creds in data.get("printers", {}).items():
-            f.write(f"[printers.{_quote_toml_key(printer_name)}]\n")
-            for key, val in creds.items():
-                f.write(f'{key} = "{_escape_toml_value(str(val))}"\n')
-            f.write("\n")
-
     if sys.platform != "win32":
-        path.chmod(0o600)
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w") as f:
+            _write_credentials_toml(f, data)
+    else:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as f:
+            _write_credentials_toml(f, data)
+
+
+def _write_credentials_toml(f, data: dict) -> None:  # noqa: ANN001
+    """Write credentials data as TOML to an open file handle."""
+    cloud = data.get("cloud", {})
+    if cloud:
+        f.write("[cloud]\n")
+        for key, val in cloud.items():
+            f.write(f'{key} = "{_escape_toml_value(str(val))}"\n')
+        f.write("\n")
+
+    for printer_name, creds in data.get("printers", {}).items():
+        f.write(f"[printers.{_quote_toml_key(printer_name)}]\n")
+        for key, val in creds.items():
+            f.write(f'{key} = "{_escape_toml_value(str(val))}"\n')
+        f.write("\n")
 
 
 def load_cloud_credentials() -> dict[str, str] | None:
@@ -219,17 +227,23 @@ def cloud_token_json():
     }
 
     cache_dir = _cache_dir()
-    tmp = tempfile.NamedTemporaryFile(
-        mode="w", suffix=".json", prefix="bambu_token_", dir=cache_dir, delete=False
-    )
-    try:
+    if sys.platform != "win32":
+        fd = tempfile.mkstemp(suffix=".json", prefix="bambu_token_", dir=str(cache_dir))
+        os.fchmod(fd[0], 0o600)
+        with os.fdopen(fd[0], "w") as f:
+            json.dump(bridge_data, f)
+        tmp_path = Path(fd[1])
+    else:
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", prefix="bambu_token_", dir=cache_dir, delete=False
+        )
         json.dump(bridge_data, tmp)
         tmp.close()
-        if sys.platform != "win32":
-            Path(tmp.name).chmod(0o600)
-        yield Path(tmp.name)
+        tmp_path = Path(tmp.name)
+    try:
+        yield tmp_path
     finally:
         try:
-            os.unlink(tmp.name)
+            os.unlink(tmp_path)
         except OSError:
             pass


### PR DESCRIPTION
## Summary
- `_write_credentials()`: use `os.open()` with explicit `0o600` mode instead of `open()` + `chmod()`
- `_write_token_json()` (bridge.py): use `mkstemp` + `fchmod` instead of `NamedTemporaryFile` + `chmod()`
- `cloud_token_json()` (credentials.py): same `mkstemp` + `fchmod` fix
- Parent directories (`~/.config/bambox/`, `~/.cache/bambox/`) now created with `0o700`

Eliminates the race window where credential files containing cloud auth tokens are briefly world-readable.

Fixes #139

## Test plan
- [x] 573 tests pass (80 credential + bridge specific)
- [x] `test_file_permissions` tests pass for both credentials.toml and token JSON
- [x] ruff check, ruff format, mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)