### PR TITLE
Use daemon HTTP API for fast watch-mode polling

### DIFF
--- a/bridge/src/main.rs
+++ b/bridge/src/main.rs
@@ -524,6 +524,7 @@ async fn main() {
 
             let agent_handle = handle::spawn_agent_thread(agent);
             let state = server::AppState::new(agent_handle, printers);
+            server::spawn_cache_updater(state.clone());
             let app = server::router(state);
 
             let addr: SocketAddr = format!("{bind}:{port}")

--- a/bridge/src/server.rs
+++ b/bridge/src/server.rs
@@ -1,14 +1,18 @@
 //! axum HTTP server exposing printer status over HTTP.
 //!
+//! A background task drains MQTT messages every ~1s and updates the device
+//! cache. Once a device has been queried via `/status`, its MQTT subscription
+//! stays active and the printer pushes updates every ~1-2s, keeping the cache
+//! perpetually fresh. Subsequent HTTP requests return instantly from cache.
+//!
 //! Endpoints:
 //!   GET  /health            — daemon health + MQTT connection state
 //!   GET  /printers          — list configured printers with cached status summary
 //!   GET  /status/:device_id — cached printer status (instant) or live query
 //!   GET  /ams/:device_id    — AMS tray info extracted from cached status
 //!   POST /cancel/:device_id — cancel current print
-//!   WS   /watch/:device_id  — (Phase 2b, not yet implemented)
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
@@ -45,6 +49,8 @@ pub struct AppState {
     pub handle: AgentHandle,
     /// Cached printer status per device_id.
     pub cache: RwLock<HashMap<String, DeviceStatus>>,
+    /// Devices with active MQTT subscriptions (cache kept fresh by background task).
+    pub subscribed_devices: RwLock<HashSet<String>>,
     /// Configured printers from credentials file.
     pub printers: Vec<PrinterEntry>,
     /// When the daemon started.
@@ -58,6 +64,7 @@ impl AppState {
         Arc::new(Self {
             handle,
             cache: RwLock::new(HashMap::new()),
+            subscribed_devices: RwLock::new(HashSet::new()),
             printers: printers
                 .into_iter()
                 .map(|(name, serial)| PrinterEntry { name, serial })
@@ -146,17 +153,29 @@ async fn get_status(
     State(state): State<SharedState>,
     Path(device_id): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    // Check cache first — return if fresh (< 30s old)
+    // If this device has an active MQTT subscription, the background task keeps
+    // the cache fresh (~1-2s updates from the printer). Return cached if < 10s.
+    let is_subscribed = state
+        .subscribed_devices
+        .read()
+        .unwrap()
+        .contains(&device_id);
+
     {
         let cache = state.cache.read().unwrap();
         if let Some(cached) = cache.get(&device_id) {
-            if cached.updated_at.elapsed() < Duration::from_secs(30) {
+            let max_age = if is_subscribed {
+                Duration::from_secs(10)
+            } else {
+                Duration::from_secs(30)
+            };
+            if cached.updated_at.elapsed() < max_age {
                 return Ok(Json(cached.payload.clone()));
             }
         }
     }
 
-    // Cache miss or stale — do a live query via the agent channel
+    // First request for this device (or stale) — subscribe and get initial status
     state
         .handle
         .drain_messages()
@@ -196,16 +215,20 @@ async fn get_status(
         }
     };
 
-    // Update cache
+    // Update cache and mark as subscribed — background task will keep it fresh
     {
         let mut cache = state.cache.write().unwrap();
         cache.insert(
-            device_id,
+            device_id.clone(),
             DeviceStatus {
                 payload: payload.clone(),
                 updated_at: Instant::now(),
             },
         );
+    }
+    {
+        let mut subs = state.subscribed_devices.write().unwrap();
+        subs.insert(device_id);
     }
 
     Ok(Json(payload))
@@ -520,16 +543,22 @@ async fn get_printer_status_for_ams(
     let best = messages.iter().max_by_key(|m| m.payload.len());
     let result = best.and_then(|msg| serde_json::from_str::<serde_json::Value>(&msg.payload).ok());
 
-    // Cache the result if we got one
+    // Cache the result and mark as subscribed
     if let Some(ref payload) = result {
-        let mut cache = state.cache.write().unwrap();
-        cache.insert(
-            device_id_owned,
-            DeviceStatus {
-                payload: payload.clone(),
-                updated_at: Instant::now(),
-            },
-        );
+        {
+            let mut cache = state.cache.write().unwrap();
+            cache.insert(
+                device_id_owned.clone(),
+                DeviceStatus {
+                    payload: payload.clone(),
+                    updated_at: Instant::now(),
+                },
+            );
+        }
+        {
+            let mut subs = state.subscribed_devices.write().unwrap();
+            subs.insert(device_id_owned);
+        }
     }
 
     result
@@ -537,6 +566,73 @@ async fn get_printer_status_for_ams(
 
 fn err(status: StatusCode, msg: String) -> (StatusCode, Json<ErrorResponse>) {
     (status, Json(ErrorResponse { error: msg }))
+}
+
+// ---------------------------------------------------------------------------
+// Background cache updater
+// ---------------------------------------------------------------------------
+
+/// Spawn a background task that drains MQTT messages every second and updates
+/// the device cache. Once a device has been subscribed (via `get_status`), the
+/// printer pushes status updates every ~1-2s over MQTT. This task picks them
+/// up and keeps the cache perpetually fresh so HTTP requests are always instant.
+pub fn spawn_cache_updater(state: SharedState) {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+
+            // Only drain if there are subscribed devices
+            let has_subs = !state.subscribed_devices.read().unwrap().is_empty();
+            if !has_subs {
+                continue;
+            }
+
+            let messages = match state.handle.drain_messages().await {
+                Ok(msgs) => msgs,
+                Err(_) => continue,
+            };
+
+            if messages.is_empty() {
+                continue;
+            }
+
+            // Group messages by device_id, keep the best (largest) per device
+            let mut best_per_device: HashMap<String, &crate::callbacks::MqttMessage> =
+                HashMap::new();
+            for msg in &messages {
+                if msg.dev_id.is_empty() {
+                    continue;
+                }
+                let entry = best_per_device.entry(msg.dev_id.clone()).or_insert(msg);
+                if msg.payload.len() > entry.payload.len() {
+                    *entry = msg;
+                }
+            }
+
+            // Update cache for each device that sent messages
+            let mut cache = state.cache.write().unwrap();
+            for (dev_id, msg) in best_per_device {
+                // Only cache messages that look like full status (have gcode_state)
+                if msg.payload.len() < 100 || !msg.payload.contains("gcode_state") {
+                    continue;
+                }
+                if let Ok(payload) = serde_json::from_str::<serde_json::Value>(&msg.payload) {
+                    tracing::trace!(
+                        device_id = %dev_id,
+                        payload_len = msg.payload.len(),
+                        "cache updated by background task"
+                    );
+                    cache.insert(
+                        dev_id,
+                        DeviceStatus {
+                            payload,
+                            updated_at: Instant::now(),
+                        },
+                    );
+                }
+            }
+        }
+    });
 }
 
 // ---------------------------------------------------------------------------
@@ -571,6 +667,7 @@ pub fn mock_state_with_printers(
                 })
                 .collect(),
         ),
+        subscribed_devices: RwLock::new(HashSet::new()),
         printers: printers
             .into_iter()
             .map(|(name, serial)| PrinterEntry { name, serial })

--- a/changes/+daemon-watch.feature
+++ b/changes/+daemon-watch.feature
@@ -1,1 +1,1 @@
-``bambox status -w`` now auto-starts the Rust daemon for fast sub-second polling via HTTP instead of spawning a new bridge process per refresh.
+``bambox status -w`` now auto-starts the Rust daemon for fast polling via HTTP instead of spawning a new bridge process per refresh. The daemon keeps MQTT subscriptions alive and updates its cache every ~1s from printer push messages, so subsequent queries are always instant.

--- a/changes/+daemon-watch.feature
+++ b/changes/+daemon-watch.feature
@@ -1,0 +1,1 @@
+``bambox status -w`` now auto-starts the Rust daemon for fast sub-second polling via HTTP instead of spawning a new bridge process per refresh.

--- a/src/bambox/bridge.py
+++ b/src/bambox/bridge.py
@@ -468,6 +468,76 @@ def _patch_config_3mf_colors(
 
 
 # ---------------------------------------------------------------------------
+# Daemon client — auto-start and query via HTTP
+# ---------------------------------------------------------------------------
+
+DAEMON_URL = "http://127.0.0.1:8765"
+
+
+def _daemon_ping() -> bool:
+    """Return True if a bridge daemon is responding on localhost:8765."""
+    import urllib.request
+
+    try:
+        req = urllib.request.Request(f"{DAEMON_URL}/ping", method="GET")
+        with urllib.request.urlopen(req, timeout=2) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
+
+
+def _start_daemon(token_file: Path, *, verbose: bool = False) -> bool:
+    """Start the bridge daemon in the background.  Returns True if started."""
+    binary = _find_local_bridge()
+    if not binary:
+        return False
+
+    cmd = [binary]
+    if verbose:
+        cmd.append("-v")
+    cmd.extend(["-c", str(token_file.resolve()), "daemon", "--port", "8765"])
+    log.debug("Starting daemon: %s", " ".join(cmd))
+    subprocess.Popen(
+        cmd,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+    # Wait for it to become responsive
+    import time
+
+    for _ in range(30):
+        time.sleep(0.5)
+        if _daemon_ping():
+            return True
+    log.warning("Daemon started but not responding after 15s")
+    return False
+
+
+def _ensure_daemon(token_file: Path, *, verbose: bool = False) -> bool:
+    """Ensure a daemon is running.  Returns True if available."""
+    if _daemon_ping():
+        return True
+    log.info("No daemon running, starting one...")
+    return _start_daemon(token_file, verbose=verbose)
+
+
+def query_status_daemon(device_id: str) -> dict:
+    """Query printer status via the HTTP daemon (fast, uses cached MQTT data)."""
+    import urllib.request
+
+    url = f"{DAEMON_URL}/status/{device_id}"
+    req = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read())
+            return data.get("print", data)
+    except Exception as e:
+        raise RuntimeError(f"Daemon query failed: {e}") from e
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 

--- a/src/bambox/cli.py
+++ b/src/bambox/cli.py
@@ -1034,18 +1034,36 @@ def _status_watch(
     print_header: Callable,
     verbose: bool,
 ) -> None:
-    """Watch mode: poll status and refresh display in-place (no screen clear)."""
+    """Watch mode: use daemon for fast polling, refresh display in-place."""
     from datetime import datetime, timezone
 
-    from bambox.bridge import parse_ams_trays, query_status
+    from bambox.bridge import (
+        _ensure_daemon,
+        parse_ams_trays,
+        query_status,
+        query_status_daemon,
+    )
+
+    use_daemon = _ensure_daemon(token_file, verbose=verbose)
+    if use_daemon:
+        ui.console.print("[dim]Connected via daemon (fast mode)[/dim]")
+    else:
+        ui.console.print("[dim]Daemon not available, using poll mode[/dim]")
 
     last_lines = 0
     try:
         while True:
             try:
-                st = query_status(device_id, token_file, verbose=verbose)
+                if use_daemon:
+                    st = query_status_daemon(device_id)
+                else:
+                    st = query_status(device_id, token_file, verbose=verbose)
                 trays = parse_ams_trays(st)
             except Exception as e:
+                if use_daemon:
+                    # Daemon may have died — fall back to poll
+                    use_daemon = False
+                    continue
                 ui.error(f"Query failed: {e}")
                 time.sleep(interval)
                 continue
@@ -1058,7 +1076,8 @@ def _status_watch(
             output = _format_status(st, ams_trays=trays)
             now = datetime.now(tz=timezone.utc).astimezone()
             timestamp = now.strftime("%H:%M:%S")
-            output += f"\n  [dim]Updated {timestamp}  (Ctrl-C to exit)[/dim]"
+            mode = "daemon" if use_daemon else "poll"
+            output += f"\n  [dim]Updated {timestamp} [{mode}]  (Ctrl-C to exit)[/dim]"
             ui.console.print(output)
 
             # Count lines for next overwrite (+1 for the header)

--- a/src/bambox/cli.py
+++ b/src/bambox/cli.py
@@ -991,8 +991,9 @@ def status(
         bool, typer.Option("-w", "--watch", help="Continuously refresh status display")
     ] = False,
     interval: Annotated[
-        int, typer.Option("-i", "--interval", help="Seconds between refreshes in watch mode")
-    ] = 10,
+        int,
+        typer.Option("-i", "--interval", help="Poll-mode refresh interval (daemon uses 1s)"),
+    ] = 5,
 ) -> None:
     """Query printer status."""
     from bambox.bridge import _write_token_json, load_credentials, parse_ams_trays, query_status
@@ -1083,7 +1084,8 @@ def _status_watch(
             # Count lines for next overwrite (+1 for the header)
             last_lines = output.count("\n") + 2
 
-            time.sleep(interval)
+            # Daemon cache refreshes every ~1s; poll mode is expensive (process per call)
+            time.sleep(1 if use_daemon else interval)
     except KeyboardInterrupt:
         ui.console.print()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -891,6 +891,7 @@ class TestStatusWatchArgs:
         with (
             patch("bambox.bridge.load_credentials", return_value=creds),
             patch("bambox.bridge._write_token_json", return_value=token),
+            patch("bambox.bridge._ensure_daemon", return_value=False),
             patch("bambox.bridge.query_status", return_value=status),
             patch("bambox.bridge.parse_ams_trays", return_value=[]),
             patch("time.sleep", side_effect=KeyboardInterrupt) as mock_sleep,
@@ -906,6 +907,7 @@ class TestStatusWatchArgs:
         with (
             patch("bambox.bridge.load_credentials", return_value=creds),
             patch("bambox.bridge._write_token_json", return_value=token),
+            patch("bambox.bridge._ensure_daemon", return_value=False),
             patch("bambox.bridge.query_status", return_value=status),
             patch("bambox.bridge.parse_ams_trays", return_value=[]),
             patch("time.sleep", side_effect=KeyboardInterrupt),


### PR DESCRIPTION
## Summary
- `bambox status -w` now auto-starts the Rust `bambox-bridge` daemon and queries its HTTP API (`localhost:8765/status/:device_id`) for instant cached status responses
- Falls back gracefully to per-call polling if the local binary is unavailable (e.g. Docker-only setups)
- Eliminates the 8-10s MQTT reconnect delay on each poll cycle when the daemon is running

## Test plan
- [x] All 573 tests pass
- [x] Lint, format, mypy all clean
- [ ] Live test: `bambox status -w <printer>` with local bridge binary — should show "daemon (fast mode)" and refresh instantly
- [ ] Live test: without local binary — should fall back to "poll mode"

🤖 Generated with [Claude Code](https://claude.com/claude-code)