### PR TITLE
Release v0.4.0

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -63,11 +63,13 @@ jobs:
           fi
           git checkout -b "$BRANCH"
 
-      - name: Bump version in pyproject.toml
+      - name: Bump version in pyproject.toml and bridge/Cargo.toml
         run: |
           VERSION="${{ inputs.version }}"
           sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" pyproject.toml
           grep "^version = \"${VERSION}\"" pyproject.toml
+          sed -i "0,/^version = \".*\"/s//version = \"${VERSION}\"/" bridge/Cargo.toml
+          grep "^version = \"${VERSION}\"" bridge/Cargo.toml
 
       - name: Build changelog with towncrier
         run: |
@@ -87,7 +89,7 @@ jobs:
           BRANCH="release/v${VERSION}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml CHANGELOG.md changes/
+          git add pyproject.toml bridge/Cargo.toml CHANGELOG.md changes/
           git commit -m "Release v${VERSION}"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git push --force origin "$BRANCH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,12 @@ jobs:
             echo "::error::Version mismatch: pyproject.toml=$TOML_VERSION, release=$VERSION"
             exit 1
           fi
+
+          CARGO_VERSION=$(grep -m1 '^version = ' bridge/Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          if [[ "$CARGO_VERSION" != "$VERSION" ]]; then
+            echo "::error::Version mismatch: bridge/Cargo.toml=$CARGO_VERSION, release=$VERSION"
+            exit 1
+          fi
           echo "::notice::Releasing version $VERSION"
 
   # ── Build package ───────────────────────────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ This changelog is managed by [towncrier](https://towncrier.readthedocs.io/).
 
 <!-- towncrier release notes start -->
 
+## 0.4.0 — 2026-04-11
+
+### Features
+
+- Add ``print`` and ``cancel`` CLI subcommands to the Rust bridge, reaching CLI parity with the legacy C++ bridge.
+- ``bambox status -w`` now auto-starts the Rust daemon for fast polling via HTTP instead of spawning a new bridge process per refresh. The daemon keeps MQTT subscriptions alive and updates its cache every ~1s from printer push messages, so subsequent queries are always instant.
+
+### Bugfixes
+
+- Fix credentials file briefly world-readable before chmod — now created with 0o600 from the start using ``os.open()``/``mkstemp``, and parent directories use 0o700. ([#139](https://github.com/estampo/bambox/pull/139))
+- Fix ``bambox status`` crash when local Rust bridge is installed by translating C++ positional args to Rust ``-c/--credentials`` flag format.
+
+### Misc
+
+- Add ``install-dev.sh`` script for installing the bridge binary from the latest CI build on main.
+- Document Rust `bambox-bridge` as the replacement for the legacy C++ `estampo/cloud-bridge`: restore the bridge migration plan, add ADR-002, and update CLAUDE.md.
+- Improve ``bambox status -w``: update display in-place instead of clearing screen, and show timestamp of last update.
+- Remove all legacy C++ ``estampo/cloud-bridge`` references — Docker fallback now uses the Rust ``bambox-bridge`` image with arg translation, and the baked-image fallback has been removed.
+- Shrink bridge Docker image from 174MB to 60MB using distroless base and multi-stage fetch.
+
+
 ## 0.3.5 — 2026-04-11
 
 ### Features

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bambox-bridge"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 description = "Rust bridge daemon for Bambu Lab printers via libbambu_networking.so"
 license = "MIT"

--- a/bridge/src/main.rs
+++ b/bridge/src/main.rs
@@ -46,7 +46,7 @@ fn credentials_search_paths() -> Vec<PathBuf> {
 }
 
 #[derive(Parser)]
-#[command(name = "bambox-bridge", about = "Bambu Lab printer bridge")]
+#[command(name = "bambox-bridge", about = "Bambu Lab printer bridge", version)]
 struct Cli {
     #[command(subcommand)]
     command: Command,

--- a/changes/+bridge-migration-intent.misc
+++ b/changes/+bridge-migration-intent.misc
@@ -1,1 +1,0 @@
-Document Rust `bambox-bridge` as the replacement for the legacy C++ `estampo/cloud-bridge`: restore the bridge migration plan, add ADR-002, and update CLAUDE.md.

--- a/changes/+bridge-print-cancel.feature
+++ b/changes/+bridge-print-cancel.feature
@@ -1,1 +1,0 @@
-Add ``print`` and ``cancel`` CLI subcommands to the Rust bridge, reaching CLI parity with the legacy C++ bridge.

--- a/changes/+bridge-status-crash.bugfix
+++ b/changes/+bridge-status-crash.bugfix
@@ -1,1 +1,0 @@
-Fix ``bambox status`` crash when local Rust bridge is installed by translating C++ positional args to Rust ``-c/--credentials`` flag format.

--- a/changes/+daemon-watch.feature
+++ b/changes/+daemon-watch.feature
@@ -1,1 +1,0 @@
-``bambox status -w`` now auto-starts the Rust daemon for fast polling via HTTP instead of spawning a new bridge process per refresh. The daemon keeps MQTT subscriptions alive and updates its cache every ~1s from printer push messages, so subsequent queries are always instant.

--- a/changes/+docker-slim.misc
+++ b/changes/+docker-slim.misc
@@ -1,1 +1,0 @@
-Shrink bridge Docker image from 174MB to 60MB using distroless base and multi-stage fetch.

--- a/changes/+install-dev-script.misc
+++ b/changes/+install-dev-script.misc
@@ -1,1 +1,0 @@
-Add ``install-dev.sh`` script for installing the bridge binary from the latest CI build on main.

--- a/changes/+remove-cpp-bridge.misc
+++ b/changes/+remove-cpp-bridge.misc
@@ -1,1 +1,0 @@
-Remove all legacy C++ ``estampo/cloud-bridge`` references — Docker fallback now uses the Rust ``bambox-bridge`` image with arg translation, and the baked-image fallback has been removed.

--- a/changes/+watch-inplace.misc
+++ b/changes/+watch-inplace.misc
@@ -1,1 +1,0 @@
-Improve ``bambox status -w``: update display in-place instead of clearing screen, and show timestamp of last update.

--- a/changes/139.bugfix
+++ b/changes/139.bugfix
@@ -1,1 +1,0 @@
-Fix credentials file briefly world-readable before chmod — now created with 0o600 from the start using ``os.open()``/``mkstemp``, and parent directories use 0o700.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/bambox"]
 
 [project]
 name = "bambox"
-version = "0.3.5"
+version = "0.4.0"
 description = "Package plain G-code into Bambu Lab .gcode.3mf files"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_release_readiness.py
+++ b/tests/test_release_readiness.py
@@ -229,3 +229,32 @@ class TestCheckCodesExist:
             # Count occurrences as string literals (finding constructors)
             matches = re.findall(rf'"{code}"', source)
             assert len(matches) >= 1, f"Code {code} not found"
+
+
+# ---------------------------------------------------------------------------
+# 4. Bridge version matches Python package version
+# ---------------------------------------------------------------------------
+
+
+class TestVersionSync:
+    """Ensure bridge/Cargo.toml version stays in sync with pyproject.toml."""
+
+    def test_bridge_version_matches_python(self) -> None:
+        root = Path(__file__).parent.parent
+        pyproject = root / "pyproject.toml"
+        cargo_toml = root / "bridge" / "Cargo.toml"
+
+        import tomllib
+
+        with open(pyproject, "rb") as f:
+            py_version = tomllib.load(f)["project"]["version"]
+
+        cargo_text = cargo_toml.read_text()
+        match = re.search(r'^version\s*=\s*"([^"]+)"', cargo_text, re.MULTILINE)
+        assert match, "No version found in bridge/Cargo.toml"
+        cargo_version = match.group(1)
+
+        assert cargo_version == py_version, (
+            f"Version mismatch: bridge/Cargo.toml={cargo_version}, "
+            f"pyproject.toml={py_version}. Both must match."
+        )


### PR DESCRIPTION
## Release v0.4.0


### Features

- Add ``print`` and ``cancel`` CLI subcommands to the Rust bridge, reaching CLI parity with the legacy C++ bridge.
- ``bambox status -w`` now auto-starts the Rust daemon for fast polling via HTTP instead of spawning a new bridge process per refresh. The daemon keeps MQTT subscriptions alive and updates its cache every ~1s from printer push messages, so subsequent queries are always instant.

### Bugfixes

- Fix credentials file briefly world-readable before chmod — now created with 0o600 from the start using ``os.open()``/``mkstemp``, and parent directories use 0o700. ([#139](https://github.com/estampo/bambox/pull/139))
- Fix ``bambox status`` crash when local Rust bridge is installed by translating C++ positional args to Rust ``-c/--credentials`` flag format.

### Misc

- Add ``install-dev.sh`` script for installing the bridge binary from the latest CI build on main.
- Document Rust `bambox-bridge` as the replacement for the legacy C++ `estampo/cloud-bridge`: restore the bridge migration plan, add ADR-002, and update CLAUDE.md.
- Improve ``bambox status -w``: update display in-place instead of clearing screen, and show timestamp of last update.
- Remove all legacy C++ ``estampo/cloud-bridge`` references — Docker fallback now uses the Rust ``bambox-bridge`` image with arg translation, and the baked-image fallback has been removed.
- Shrink bridge Docker image from 174MB to 60MB using distroless base and multi-stage fetch.

---
**Merge this PR to trigger the release pipeline.**
The release workflow will build the package, validate on TestPyPI, create the tag, create the GitHub Release, then publish to PyPI.