### PR TITLE
Fix credential env var mismatch between Python and Rust bridge

### DIFF
--- a/bridge/src/main.rs
+++ b/bridge/src/main.rs
@@ -60,7 +60,7 @@ struct Cli {
     lib_path: String,
 
     /// Path to credentials file (TOML or JSON)
-    #[arg(long, short, global = true, env = "BAMBU_CREDENTIALS")]
+    #[arg(long, short, global = true, env = "BAMBOX_CREDENTIALS")]
     credentials: Option<PathBuf>,
 
     /// Disable auto-download of the networking library

--- a/changes/156.bugfix
+++ b/changes/156.bugfix
@@ -1,0 +1,1 @@
+Fix credential env var mismatch: Rust bridge now uses ``BAMBOX_CREDENTIALS`` (was ``BAMBU_CREDENTIALS``), matching the Python side. Python also checks macOS ``~/Library/Application Support/`` paths to match the bridge's search behavior.

--- a/docs/bridge-migration-plan.md
+++ b/docs/bridge-migration-plan.md
@@ -131,7 +131,7 @@ over HTTP instead of stdin/stdout.
   Eliminates bind-mount issues in DinD, sandboxed, and remote environments.
 - **MQTT persists across requests.** Status returns cached data, no 20s wait.
 - **Credentials at startup.** Token JSON passed once via `--credentials` flag
-  or `BAMBU_CREDENTIALS` env var.
+  or `BAMBOX_CREDENTIALS` env var.
 - **Localhost only.** Binds to `127.0.0.1:8765`. No auth needed.
 
 ### Dependencies
@@ -245,7 +245,7 @@ Users run:
 ```bash
 docker run -d --name bambu-bridge \
   -p 8765:8765 \
-  -e BAMBU_CREDENTIALS='{"token":"..."}' \
+  -e BAMBOX_CREDENTIALS='{"token":"..."}' \
   estampo/bambu-bridge:latest
 ```
 

--- a/src/bambox/credentials.py
+++ b/src/bambox/credentials.py
@@ -54,7 +54,9 @@ def _credentials_path() -> Path:
     2. ``ESTAMPO_CREDENTIALS`` env var (backward compat)
     3. ``~/.config/bambox/credentials.toml`` (if exists)
     4. ``~/.config/estampo/credentials.toml`` (fallback for reading)
-    5. ``~/.config/bambox/credentials.toml`` (default for new installs)
+    5. ``~/Library/Application Support/bambox/credentials.toml`` (macOS only)
+    6. ``~/Library/Application Support/estampo/credentials.toml`` (macOS only)
+    7. ``~/.config/bambox/credentials.toml`` (default for new installs)
     """
     env = os.environ.get("BAMBOX_CREDENTIALS")
     if env:
@@ -70,10 +72,18 @@ def _credentials_path() -> Path:
         bambox_path = Path.home() / ".config/bambox/credentials.toml"
         estampo_path = Path.home() / ".config/estampo/credentials.toml"
 
-    if bambox_path.exists():
-        return bambox_path
-    if estampo_path.exists():
-        return estampo_path
+    candidates = [bambox_path, estampo_path]
+
+    # On macOS, also check ~/Library/Application Support/ (platform-native config dir)
+    # to match the Rust bridge's search behavior via the `dirs` crate.
+    if sys.platform == "darwin":
+        lib_dir = Path.home() / "Library" / "Application Support"
+        candidates.append(lib_dir / "bambox" / "credentials.toml")
+        candidates.append(lib_dir / "estampo" / "credentials.toml")
+
+    for path in candidates:
+        if path.exists():
+            return path
     # Default for new installs
     return bambox_path
 


### PR DESCRIPTION
## Summary
- Align Rust bridge env var from `BAMBU_CREDENTIALS` to `BAMBOX_CREDENTIALS` to match the Python side
- Add macOS `~/Library/Application Support/` credential search paths to Python, matching the Rust bridge's `dirs` crate behavior
- Update docs/bridge-migration-plan.md references

Closes #156

## Test plan
- [x] All existing tests pass (574 passed)
- [x] Lint, format, type checks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)