### PR TITLE
Improve exception handling: log silent blocks, narrow types

### DIFF
--- a/changes/158.misc
+++ b/changes/158.misc
@@ -1,0 +1,1 @@
+Improve exception handling: add debug logging to silent except blocks, narrow broad exception types, replace ``BaseException`` catch with ``try/finally`` in credential temp-file writing.

--- a/src/bambox/bridge.py
+++ b/src/bambox/bridge.py
@@ -457,7 +457,8 @@ def _daemon_ping() -> bool:
         req = urllib.request.Request(f"{DAEMON_URL}/ping", method="GET")
         with urllib.request.urlopen(req, timeout=2) as resp:
             return resp.status == 200
-    except Exception:
+    except (OSError, urllib.error.URLError):
+        log.debug("Daemon ping failed", exc_info=True)
         return False
 
 

--- a/src/bambox/cli.py
+++ b/src/bambox/cli.py
@@ -24,6 +24,8 @@ from bambox.cura import (
 from bambox.pack import FilamentInfo, SliceInfo, pack_gcode_3mf, repack_3mf
 from bambox.settings import available_filaments, available_machines, build_project_settings
 
+log = logging.getLogger(__name__)
+
 app = typer.Typer(
     name="bambox",
     help="Package and print G-code on Bambu Lab printers",
@@ -371,8 +373,8 @@ def _show_ams_mapping(threemf: Path, ams_trays: list[dict], mapping: list[int]) 
                     for f in plate_el.findall(f"{ns}filament"):
                         fid = int(f.get("id", "1"))
                         filaments[fid] = (f.get("type", "?"), f.get("color", "?"))
-    except Exception:
-        pass
+    except (OSError, KeyError, ET.ParseError):
+        log.debug("Failed to parse slice_info for AMS display", exc_info=True)
 
     tray_by_phys = {t["phys_slot"]: t for t in ams_trays}
 

--- a/src/bambox/credentials.py
+++ b/src/bambox/credentials.py
@@ -235,15 +235,23 @@ def write_token_json(cloud: dict[str, str], directory: Path | None = None) -> Pa
     if directory:
         d.mkdir(parents=True, exist_ok=True)
     fd, path = tempfile.mkstemp(suffix=".json", prefix="bambu_token_", dir=str(d))
+    ok = False
     try:
         if sys.platform != "win32":
             os.fchmod(fd, 0o600)
         with os.fdopen(fd, "w") as f:
             json.dump(bridge_data, f)
-    except BaseException:
-        os.close(fd)
-        os.unlink(path)
-        raise
+        ok = True
+    finally:
+        if not ok:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
     return Path(path)
 
 

--- a/src/bambox/pack.py
+++ b/src/bambox/pack.py
@@ -9,12 +9,15 @@ from __future__ import annotations
 import hashlib
 import io
 import json
+import logging
 import re
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import IO
 from xml.sax.saxutils import escape as _xml_escape_base
+
+log = logging.getLogger(__name__)
 
 
 def xml_escape(value: str) -> str:
@@ -505,6 +508,7 @@ def repack_3mf(
                     size = 128 if "small" in fname else 512
                     thumbnail_overrides[fname] = gcode_thumbnail(gcode_str, size, size)
                 except Exception:
+                    log.debug("Thumbnail generation failed for %s", fname, exc_info=True)
                     thumbnail_overrides[fname] = _PLACEHOLDER_PNG
             else:
                 thumbnail_overrides[fname] = _PLACEHOLDER_PNG
@@ -645,7 +649,7 @@ def pack_gcode_3mf(
                         "Metadata/pick_1.png": main_png,
                     }
                 except Exception:
-                    pass  # fall back to placeholder
+                    log.debug("Thumbnail generation failed, using placeholders", exc_info=True)
             extra = extra_files or {}
             for path in [
                 "Metadata/plate_1.png",


### PR DESCRIPTION
## Summary
- Add `log.debug(exc_info=True)` to all silent `except: pass` blocks for debuggability
- Narrow broad `Exception` catches to specific types (`OSError`, `KeyError`, `ET.ParseError`, `URLError`)
- Replace `except BaseException` with `try/finally` in `write_token_json` to avoid masking `KeyboardInterrupt`/`SystemExit`

Closes #158

## Test plan
- [x] All 574 tests pass
- [x] Lint, format, type checks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)