### PR TITLE
Move hardcoded P1S geometry into machine profile

### DIFF
--- a/changes/160.misc
+++ b/changes/160.misc
@@ -1,0 +1,1 @@
+Move hardcoded P1S toolchange geometry coordinates from ``gcode_compat.py`` into the ``base_p1s.json`` machine profile, making them configurable per-machine.

--- a/src/bambox/gcode_compat.py
+++ b/src/bambox/gcode_compat.py
@@ -414,17 +414,16 @@ def rewrite_tool_changes(
             "default_acceleration": _int("default_acceleration", 0, 10000),
             "initial_layer_acceleration": _int("initial_layer_acceleration", 0, 500),
             "initial_layer_print_height": _num("initial_layer_print_height", 0, 0.2),
-            # Fallback positions (used when next_extruder >= 255)
-            "x_after_toolchange": 100,
-            "y_after_toolchange": 100,
-            "z_after_toolchange": layer_z + 2.0,
-            # Travel points (used on second tool change)
-            "travel_point_1_x": 20,
-            "travel_point_1_y": 50,
-            "travel_point_2_x": 60,
-            "travel_point_2_y": 245,
-            "travel_point_3_x": 70,
-            "travel_point_3_y": 265,
+            # Machine geometry for toolchange travel (from machine profile)
+            "x_after_toolchange": _num("toolchange_x_after", 0, 100),
+            "y_after_toolchange": _num("toolchange_y_after", 0, 100),
+            "z_after_toolchange": layer_z + _num("toolchange_z_offset", 0, 2.0),
+            "travel_point_1_x": _num("toolchange_travel_1_x", 0, 20),
+            "travel_point_1_y": _num("toolchange_travel_1_y", 0, 50),
+            "travel_point_2_x": _num("toolchange_travel_2_x", 0, 60),
+            "travel_point_2_y": _num("toolchange_travel_2_y", 0, 245),
+            "travel_point_3_x": _num("toolchange_travel_3_x", 0, 70),
+            "travel_point_3_y": _num("toolchange_travel_3_y", 0, 265),
         }
 
         rendered = render_template(f"{machine}_toolchange.gcode.j2", ctx)

--- a/src/bambox/profiles/base_p1s.json
+++ b/src/bambox/profiles/base_p1s.json
@@ -1624,5 +1624,14 @@
   "z_hop_types": [
     "Auto Lift",
     "Auto Lift"
-  ]
+  ],
+  "toolchange_x_after": "100",
+  "toolchange_y_after": "100",
+  "toolchange_z_offset": "2.0",
+  "toolchange_travel_1_x": "20",
+  "toolchange_travel_1_y": "50",
+  "toolchange_travel_2_x": "60",
+  "toolchange_travel_2_y": "245",
+  "toolchange_travel_3_x": "70",
+  "toolchange_travel_3_y": "265"
 }


### PR DESCRIPTION
## Summary
- Add `toolchange_*` keys to `base_p1s.json` machine profile for toolchange travel coordinates
- Update `rewrite_tool_changes()` to read geometry from project_settings instead of hardcoded values
- Fallback defaults preserve current behavior when keys are absent

Closes #160

## Test plan
- [x] All 574 tests pass
- [x] Lint, format, type checks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)