### PR TITLE
Extract shared test fixtures to shared_fixtures.py

### DIFF
--- a/changes/161.misc
+++ b/changes/161.misc
@@ -1,0 +1,1 @@
+Extract shared test constants (``MINIMAL_GCODE``, ``MINIMAL_SLICE_INFO``, ``MINIMAL_SETTINGS``) and ``build_valid_3mf()`` into ``tests/conftest.py``, removing duplication between test_validate.py and test_release_readiness.py.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ select = ["E", "F", "I", "W"]
 "src/bambox/pack.py" = ["E501"]
 
 [tool.pytest.ini_options]
-pythonpath = ["src"]
+pythonpath = ["src", "tests"]
 markers = [
     "e2e: end-to-end tests requiring estampo CLI and Docker (deselect with '-m not e2e')",
 ]

--- a/tests/shared_fixtures.py
+++ b/tests/shared_fixtures.py
@@ -1,0 +1,105 @@
+"""Shared test fixtures and constants for bambox tests."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import zipfile
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Minimal valid 3MF archive data
+# ---------------------------------------------------------------------------
+
+MINIMAL_GCODE = """\
+; HEADER_BLOCK_START
+; total layer number: 3
+; total estimated time: 2m 30s
+; HEADER_BLOCK_END
+M73 P0 R2
+;LAYER_CHANGE
+;Z:0.2
+;HEIGHT:0.2
+M73 L1
+M991 S0 P1
+M73 P33 R2
+G1 X10 Y10 E1 F600
+;LAYER_CHANGE
+;Z:0.4
+;HEIGHT:0.2
+M73 L2
+M991 S0 P2
+M73 P66 R1
+G1 X20 Y20 E2 F600
+;LAYER_CHANGE
+;Z:0.6
+;HEIGHT:0.2
+M73 L3
+M991 S0 P3
+M73 P100 R0
+G1 X30 Y30 E3 F600
+"""
+
+MINIMAL_SLICE_INFO = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+  <header>
+    <header_item key="X-BBL-Client-Type" value="slicer"/>
+    <header_item key="X-BBL-Client-Version" value=""/>
+  </header>
+  <plate>
+    <metadata key="index" value="1"/>
+    <metadata key="printer_model_id" value="C12"/>
+    <metadata key="nozzle_diameters" value="0.4"/>
+    <metadata key="prediction" value="150"/>
+    <metadata key="weight" value="5.00"/>
+    <metadata key="outside" value="false"/>
+    <metadata key="support_used" value="false"/>
+    <metadata key="label_object_enabled" value="true"/>
+    <metadata key="timelapse_type" value="0"/>
+    <metadata key="filament_maps" value="1"/>
+    <filament id="1" tray_info_idx="GFL99" type="PLA" color="#F2754E" used_m="1.00" used_g="3.00" />
+  </plate>
+</config>
+"""
+
+MINIMAL_SETTINGS = json.dumps(
+    {
+        "filament_type": ["PLA", "PLA", "PLA", "PLA", "PLA"],
+        "filament_colour": ["#F2754E", "#F2754E", "#F2754E", "#F2754E", "#F2754E"],
+        "nozzle_temperature": ["220", "220", "220", "220", "220"],
+        "nozzle_temperature_initial_layer": ["220", "220", "220", "220", "220"],
+        "bed_temperature": ["60", "60", "60", "60", "60"],
+        "filament_max_volumetric_speed": ["12", "12", "12", "12", "12"],
+    }
+)
+
+
+def build_valid_3mf(
+    tmp_path: Path,
+    gcode: str = MINIMAL_GCODE,
+    slice_info: str = MINIMAL_SLICE_INFO,
+    settings: str = MINIMAL_SETTINGS,
+) -> Path:
+    """Build a minimal valid .gcode.3mf for testing."""
+    out = tmp_path / "test.gcode.3mf"
+    gcode_bytes = gcode.encode()
+    md5 = hashlib.md5(gcode_bytes).hexdigest().upper()
+
+    with zipfile.ZipFile(out, "w") as zf:
+        zf.writestr("[Content_Types].xml", "<Types/>")
+        zf.writestr("_rels/.rels", "<Relationships/>")
+        zf.writestr("3D/3dmodel.model", "<model/>")
+        zf.writestr("Metadata/plate_1.gcode", gcode_bytes)
+        zf.writestr("Metadata/plate_1.gcode.md5", md5)
+        zf.writestr("Metadata/model_settings.config", "{}")
+        zf.writestr("Metadata/_rels/model_settings.config.rels", "<Relationships/>")
+        zf.writestr("Metadata/slice_info.config", slice_info)
+        zf.writestr("Metadata/project_settings.config", settings)
+        zf.writestr("Metadata/plate_1.json", "{}")
+        zf.writestr("Metadata/plate_1.png", b"\x89PNG\r\n\x1a\n")
+        zf.writestr("Metadata/plate_no_light_1.png", b"\x89PNG\r\n\x1a\n")
+        zf.writestr("Metadata/plate_1_small.png", b"\x89PNG\r\n\x1a\n")
+        zf.writestr("Metadata/top_1.png", b"\x89PNG\r\n\x1a\n")
+        zf.writestr("Metadata/pick_1.png", b"\x89PNG\r\n\x1a\n")
+    return out

--- a/tests/test_release_readiness.py
+++ b/tests/test_release_readiness.py
@@ -7,112 +7,17 @@ has regressed.
 
 from __future__ import annotations
 
-import hashlib
-import json
 import re
-import zipfile
 from pathlib import Path
 
 import pytest
+from shared_fixtures import build_valid_3mf
 
 from bambox.validate import validate_3mf
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures" / "e2e_cura_p1s"
 REFERENCE_3MF = FIXTURE_DIR / "reference.gcode.3mf"
 TOP_LEVEL_REFERENCE = Path(__file__).parent / "fixtures" / "reference.gcode.3mf"
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-_MINIMAL_GCODE = """\
-; HEADER_BLOCK_START
-; total layer number: 3
-; total estimated time: 2m 30s
-; HEADER_BLOCK_END
-M73 P0 R2
-;LAYER_CHANGE
-;Z:0.2
-;HEIGHT:0.2
-M73 L1
-M991 S0 P1
-M73 P33 R2
-G1 X10 Y10 E1 F600
-;LAYER_CHANGE
-;Z:0.4
-;HEIGHT:0.2
-M73 L2
-M991 S0 P2
-M73 P66 R1
-G1 X20 Y20 E2 F600
-;LAYER_CHANGE
-;Z:0.6
-;HEIGHT:0.2
-M73 L3
-M991 S0 P3
-M73 P100 R0
-G1 X30 Y30 E3 F600
-"""
-
-_MINIMAL_SLICE_INFO = """\
-<?xml version="1.0" encoding="UTF-8"?>
-<config>
-  <header>
-    <header_item key="X-BBL-Client-Type" value="slicer"/>
-    <header_item key="X-BBL-Client-Version" value=""/>
-  </header>
-  <plate>
-    <metadata key="index" value="1"/>
-    <metadata key="printer_model_id" value="C12"/>
-    <metadata key="nozzle_diameters" value="0.4"/>
-    <metadata key="prediction" value="150"/>
-    <metadata key="weight" value="5.00"/>
-    <metadata key="outside" value="false"/>
-    <metadata key="support_used" value="false"/>
-    <metadata key="label_object_enabled" value="true"/>
-    <metadata key="timelapse_type" value="0"/>
-    <metadata key="filament_maps" value="1"/>
-    <filament id="1" tray_info_idx="GFL99" type="PLA" color="#F2754E" used_m="1.00" used_g="3.00" />
-  </plate>
-</config>
-"""
-
-_MINIMAL_SETTINGS = json.dumps(
-    {
-        "filament_type": ["PLA", "PLA", "PLA", "PLA", "PLA"],
-        "filament_colour": ["#F2754E", "#F2754E", "#F2754E", "#F2754E", "#F2754E"],
-        "nozzle_temperature": ["220", "220", "220", "220", "220"],
-        "nozzle_temperature_initial_layer": ["220", "220", "220", "220", "220"],
-        "bed_temperature": ["60", "60", "60", "60", "60"],
-        "filament_max_volumetric_speed": ["12", "12", "12", "12", "12"],
-    }
-)
-
-
-def _build_valid_3mf(tmp_path: Path) -> Path:
-    """Build a minimal valid .gcode.3mf for testing."""
-    out = tmp_path / "test.gcode.3mf"
-    gcode_bytes = _MINIMAL_GCODE.encode()
-    md5 = hashlib.md5(gcode_bytes).hexdigest().upper()
-
-    with zipfile.ZipFile(out, "w") as zf:
-        zf.writestr("[Content_Types].xml", "<Types/>")
-        zf.writestr("_rels/.rels", "<Relationships/>")
-        zf.writestr("3D/3dmodel.model", "<model/>")
-        zf.writestr("Metadata/plate_1.gcode", gcode_bytes)
-        zf.writestr("Metadata/plate_1.gcode.md5", md5)
-        zf.writestr("Metadata/model_settings.config", "{}")
-        zf.writestr("Metadata/_rels/model_settings.config.rels", "<Relationships/>")
-        zf.writestr("Metadata/slice_info.config", _MINIMAL_SLICE_INFO)
-        zf.writestr("Metadata/project_settings.config", _MINIMAL_SETTINGS)
-        zf.writestr("Metadata/plate_1.json", "{}")
-        zf.writestr("Metadata/plate_1.png", b"\x89PNG\r\n\x1a\n")
-        zf.writestr("Metadata/plate_no_light_1.png", b"\x89PNG\r\n\x1a\n")
-        zf.writestr("Metadata/plate_1_small.png", b"\x89PNG\r\n\x1a\n")
-        zf.writestr("Metadata/top_1.png", b"\x89PNG\r\n\x1a\n")
-        zf.writestr("Metadata/pick_1.png", b"\x89PNG\r\n\x1a\n")
-    return out
 
 
 # ---------------------------------------------------------------------------
@@ -141,7 +46,7 @@ class TestReferenceFixture:
 
 class TestFreshBuildValidation:
     def test_built_archive_zero_errors(self, tmp_path: Path) -> None:
-        path = _build_valid_3mf(tmp_path)
+        path = build_valid_3mf(tmp_path)
         result = validate_3mf(path)
         assert result.valid, [f"{f.code}: {f.message}" for f in result.errors]
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -8,6 +8,12 @@ import zipfile
 from pathlib import Path
 
 import pytest
+from shared_fixtures import (
+    MINIMAL_GCODE,
+    MINIMAL_SETTINGS,
+    MINIMAL_SLICE_INFO,
+    build_valid_3mf,
+)
 
 from bambox.validate import (
     Severity,
@@ -19,105 +25,6 @@ from bambox.validate import (
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures" / "e2e_cura_p1s"
 REFERENCE_3MF = FIXTURE_DIR / "reference.gcode.3mf"
-
-
-# ---------------------------------------------------------------------------
-# Helpers — build minimal valid archives for testing
-# ---------------------------------------------------------------------------
-
-# Minimal BBL-compatible gcode with all required markers
-_MINIMAL_GCODE = """\
-; HEADER_BLOCK_START
-; total layer number: 3
-; total estimated time: 2m 30s
-; HEADER_BLOCK_END
-M73 P0 R2
-;LAYER_CHANGE
-;Z:0.2
-;HEIGHT:0.2
-M73 L1
-M991 S0 P1
-M73 P33 R2
-G1 X10 Y10 E1 F600
-;LAYER_CHANGE
-;Z:0.4
-;HEIGHT:0.2
-M73 L2
-M991 S0 P2
-M73 P66 R1
-G1 X20 Y20 E2 F600
-;LAYER_CHANGE
-;Z:0.6
-;HEIGHT:0.2
-M73 L3
-M991 S0 P3
-M73 P100 R0
-G1 X30 Y30 E3 F600
-"""
-
-_MINIMAL_SLICE_INFO = """\
-<?xml version="1.0" encoding="UTF-8"?>
-<config>
-  <header>
-    <header_item key="X-BBL-Client-Type" value="slicer"/>
-    <header_item key="X-BBL-Client-Version" value=""/>
-  </header>
-  <plate>
-    <metadata key="index" value="1"/>
-    <metadata key="printer_model_id" value="C12"/>
-    <metadata key="nozzle_diameters" value="0.4"/>
-    <metadata key="prediction" value="150"/>
-    <metadata key="weight" value="5.00"/>
-    <metadata key="outside" value="false"/>
-    <metadata key="support_used" value="false"/>
-    <metadata key="label_object_enabled" value="true"/>
-    <metadata key="timelapse_type" value="0"/>
-    <metadata key="filament_maps" value="1"/>
-    <filament id="1" tray_info_idx="GFL99" type="PLA" color="#F2754E" used_m="1.00" used_g="3.00" />
-  </plate>
-</config>
-"""
-
-_MINIMAL_SETTINGS = json.dumps(
-    {
-        "filament_type": ["PLA", "PLA", "PLA", "PLA", "PLA"],
-        "filament_colour": ["#F2754E", "#F2754E", "#F2754E", "#F2754E", "#F2754E"],
-        "nozzle_temperature": ["220", "220", "220", "220", "220"],
-        "nozzle_temperature_initial_layer": ["220", "220", "220", "220", "220"],
-        "bed_temperature": ["60", "60", "60", "60", "60"],
-        "filament_max_volumetric_speed": ["12", "12", "12", "12", "12"],
-    }
-)
-
-
-def _build_valid_3mf(
-    tmp_path: Path,
-    gcode: str = _MINIMAL_GCODE,
-    slice_info: str = _MINIMAL_SLICE_INFO,
-    settings: str = _MINIMAL_SETTINGS,
-) -> Path:
-    """Build a minimal valid .gcode.3mf for testing."""
-    out = tmp_path / "test.gcode.3mf"
-    gcode_bytes = gcode.encode()
-    md5 = hashlib.md5(gcode_bytes).hexdigest().upper()
-
-    with zipfile.ZipFile(out, "w") as zf:
-        zf.writestr("[Content_Types].xml", "<Types/>")
-        zf.writestr("_rels/.rels", "<Relationships/>")
-        zf.writestr("3D/3dmodel.model", "<model/>")
-        zf.writestr("Metadata/plate_1.gcode", gcode_bytes)
-        zf.writestr("Metadata/plate_1.gcode.md5", md5)
-        zf.writestr("Metadata/model_settings.config", "{}")
-        zf.writestr("Metadata/_rels/model_settings.config.rels", "<Relationships/>")
-        zf.writestr("Metadata/slice_info.config", slice_info)
-        zf.writestr("Metadata/project_settings.config", settings)
-        zf.writestr("Metadata/plate_1.json", "{}")
-        zf.writestr("Metadata/plate_1.png", b"\x89PNG\r\n\x1a\n")
-        zf.writestr("Metadata/plate_no_light_1.png", b"\x89PNG\r\n\x1a\n")
-        zf.writestr("Metadata/plate_1_small.png", b"\x89PNG\r\n\x1a\n")
-        zf.writestr("Metadata/top_1.png", b"\x89PNG\r\n\x1a\n")
-        zf.writestr("Metadata/pick_1.png", b"\x89PNG\r\n\x1a\n")
-    return out
 
 
 # ---------------------------------------------------------------------------
@@ -189,12 +96,12 @@ class TestReferenceArchive:
 
 class TestValidArchive:
     def test_minimal_valid_passes(self, tmp_path: Path) -> None:
-        path = _build_valid_3mf(tmp_path)
+        path = build_valid_3mf(tmp_path)
         result = validate_3mf(path)
         assert result.valid, [f"{f.code}: {f.message}" for f in result.errors]
 
     def test_buffer_api(self, tmp_path: Path) -> None:
-        path = _build_valid_3mf(tmp_path)
+        path = build_valid_3mf(tmp_path)
         with open(path, "rb") as fh:
             result = validate_3mf_buffer(fh)
         assert result.valid
@@ -221,20 +128,20 @@ class TestBadZip:
 
 class TestTemperatureCommands:
     def test_array_as_scalar(self, tmp_path: Path) -> None:
-        gcode = _MINIMAL_GCODE + "M104 S[220]\n"
-        path = _build_valid_3mf(tmp_path, gcode=gcode)
+        gcode = MINIMAL_GCODE + "M104 S[220]\n"
+        path = build_valid_3mf(tmp_path, gcode=gcode)
         result = validate_3mf(path)
         assert any(f.code == "E001" for f in result.errors)
 
     def test_template_in_temp(self, tmp_path: Path) -> None:
-        gcode = _MINIMAL_GCODE + "M109 S{nozzle_temp}\n"
-        path = _build_valid_3mf(tmp_path, gcode=gcode)
+        gcode = MINIMAL_GCODE + "M109 S{nozzle_temp}\n"
+        path = build_valid_3mf(tmp_path, gcode=gcode)
         result = validate_3mf(path)
         assert any(f.code == "E001" for f in result.errors)
 
     def test_valid_temps_pass(self, tmp_path: Path) -> None:
-        gcode = _MINIMAL_GCODE + "M104 S220\nM109 S220\nM140 S60\n"
-        path = _build_valid_3mf(tmp_path, gcode=gcode)
+        gcode = MINIMAL_GCODE + "M104 S220\nM109 S220\nM140 S60\n"
+        path = build_valid_3mf(tmp_path, gcode=gcode)
         result = validate_3mf(path)
         assert not any(f.code == "E001" for f in result.findings)
 
@@ -246,14 +153,14 @@ class TestTemperatureCommands:
 
 class TestToolchangeFeedrate:
     def test_low_feedrate_detected(self, tmp_path: Path) -> None:
-        gcode = _MINIMAL_GCODE + "M620.1 E F12 T240\n"
-        path = _build_valid_3mf(tmp_path, gcode=gcode)
+        gcode = MINIMAL_GCODE + "M620.1 E F12 T240\n"
+        path = build_valid_3mf(tmp_path, gcode=gcode)
         result = validate_3mf(path)
         assert any(f.code == "E002" for f in result.errors)
 
     def test_correct_feedrate_passes(self, tmp_path: Path) -> None:
-        gcode = _MINIMAL_GCODE + "M620.1 E F299 T240\n"
-        path = _build_valid_3mf(tmp_path, gcode=gcode)
+        gcode = MINIMAL_GCODE + "M620.1 E F299 T240\n"
+        path = build_valid_3mf(tmp_path, gcode=gcode)
         result = validate_3mf(path)
         assert not any(f.code == "E002" for f in result.findings)
 
@@ -265,7 +172,7 @@ class TestToolchangeFeedrate:
 
 class TestMD5:
     def test_mismatch_detected(self, tmp_path: Path) -> None:
-        path = _build_valid_3mf(tmp_path)
+        path = build_valid_3mf(tmp_path)
         # Corrupt MD5
         with zipfile.ZipFile(path, "a") as zf:
             zf.writestr("Metadata/plate_1.gcode.md5", "DEADBEEF" * 4)
@@ -273,7 +180,7 @@ class TestMD5:
         assert any(f.code == "E003" for f in result.errors)
 
     def test_valid_md5_passes(self, tmp_path: Path) -> None:
-        path = _build_valid_3mf(tmp_path)
+        path = build_valid_3mf(tmp_path)
         result = validate_3mf(path)
         assert not any(f.code == "E003" for f in result.findings)
 
@@ -286,12 +193,12 @@ class TestMD5:
 class TestArrayPadding:
     def test_short_array_detected(self, tmp_path: Path) -> None:
         settings = json.dumps({"filament_type": ["PLA", "PLA"]})
-        path = _build_valid_3mf(tmp_path, settings=settings)
+        path = build_valid_3mf(tmp_path, settings=settings)
         result = validate_3mf(path)
         assert any(f.code == "E004" for f in result.errors)
 
     def test_full_array_passes(self, tmp_path: Path) -> None:
-        path = _build_valid_3mf(tmp_path)
+        path = build_valid_3mf(tmp_path)
         result = validate_3mf(path)
         assert not any(f.code == "E004" for f in result.findings)
 
@@ -303,14 +210,14 @@ class TestArrayPadding:
 
 class TestUnsubstitutedTemplates:
     def test_template_in_command(self, tmp_path: Path) -> None:
-        gcode = _MINIMAL_GCODE + "G1 X{first_layer_print_min} Y10 F600\n"
-        path = _build_valid_3mf(tmp_path, gcode=gcode)
+        gcode = MINIMAL_GCODE + "G1 X{first_layer_print_min} Y10 F600\n"
+        path = build_valid_3mf(tmp_path, gcode=gcode)
         result = validate_3mf(path)
         assert any(f.code == "E005" for f in result.errors)
 
     def test_template_in_comment_is_ok(self, tmp_path: Path) -> None:
-        gcode = _MINIMAL_GCODE + "; {perimeter}\n"
-        path = _build_valid_3mf(tmp_path, gcode=gcode)
+        gcode = MINIMAL_GCODE + "; {perimeter}\n"
+        path = build_valid_3mf(tmp_path, gcode=gcode)
         result = validate_3mf(path)
         assert not any(f.code == "E005" for f in result.findings)
 
@@ -330,7 +237,7 @@ class TestRequiredFiles:
         assert len(e006) > 0
 
     def test_valid_has_all_files(self, tmp_path: Path) -> None:
-        path = _build_valid_3mf(tmp_path)
+        path = build_valid_3mf(tmp_path)
         result = validate_3mf(path)
         assert not any(f.code == "E006" for f in result.findings)
 
@@ -343,13 +250,13 @@ class TestRequiredFiles:
 class TestHeaderBlock:
     def test_missing_header_block(self, tmp_path: Path) -> None:
         gcode = "G28\nG1 X10 Y10 E1 F600\n"
-        path = _build_valid_3mf(tmp_path, gcode=gcode)
+        path = build_valid_3mf(tmp_path, gcode=gcode)
         result = validate_3mf(path)
         assert any(f.code == "E007" for f in result.errors)
 
     def test_zero_layer_count(self, tmp_path: Path) -> None:
         gcode = "; HEADER_BLOCK_START\n; total layer number: 0\n; HEADER_BLOCK_END\nG28\n"
-        path = _build_valid_3mf(tmp_path, gcode=gcode)
+        path = build_valid_3mf(tmp_path, gcode=gcode)
         result = validate_3mf(path)
         assert any(f.code == "E008" for f in result.errors)
 
@@ -368,7 +275,7 @@ class TestLayerMarkers:
             "M991 S0 P1\n"
             "G1 X10 E1 F600\n"
         )
-        path = _build_valid_3mf(tmp_path, gcode=gcode)
+        path = build_valid_3mf(tmp_path, gcode=gcode)
         result = validate_3mf(path)
         assert any(f.code == "E009" for f in result.errors)
 
@@ -381,7 +288,7 @@ class TestLayerMarkers:
             "M73 P100 R0\n"
             "G1 X10 E1 F600\n"
         )
-        path = _build_valid_3mf(tmp_path, gcode=gcode)
+        path = build_valid_3mf(tmp_path, gcode=gcode)
         result = validate_3mf(path)
         assert any(f.code == "E010" for f in result.errors)
 
@@ -392,7 +299,7 @@ class TestLayerMarkers:
             "; HEADER_BLOCK_END\n"
             "M73 L1\nM991 S0 P1\nM73 P100 R0\n"
         )
-        path = _build_valid_3mf(tmp_path, gcode=gcode)
+        path = build_valid_3mf(tmp_path, gcode=gcode)
         result = validate_3mf(path)
         assert any(f.code == "E011" for f in result.errors)
 
@@ -404,20 +311,20 @@ class TestLayerMarkers:
 
 class TestMetadataWarnings:
     def test_empty_printer_model_id(self, tmp_path: Path) -> None:
-        si = _MINIMAL_SLICE_INFO.replace('value="C12"', 'value=""')
-        path = _build_valid_3mf(tmp_path, slice_info=si)
+        si = MINIMAL_SLICE_INFO.replace('value="C12"', 'value=""')
+        path = build_valid_3mf(tmp_path, slice_info=si)
         result = validate_3mf(path)
         assert any(f.code == "W001" for f in result.warnings)
 
     def test_zero_prediction(self, tmp_path: Path) -> None:
-        si = _MINIMAL_SLICE_INFO.replace('value="150"', 'value="0"')
-        path = _build_valid_3mf(tmp_path, slice_info=si)
+        si = MINIMAL_SLICE_INFO.replace('value="150"', 'value="0"')
+        path = build_valid_3mf(tmp_path, slice_info=si)
         result = validate_3mf(path)
         assert any(f.code == "W002" for f in result.warnings)
 
     def test_zero_weight(self, tmp_path: Path) -> None:
-        si = _MINIMAL_SLICE_INFO.replace('value="5.00"', 'value="0.00"')
-        path = _build_valid_3mf(tmp_path, slice_info=si)
+        si = MINIMAL_SLICE_INFO.replace('value="5.00"', 'value="0.00"')
+        path = build_valid_3mf(tmp_path, slice_info=si)
         result = validate_3mf(path)
         assert any(f.code == "W003" for f in result.warnings)
 
@@ -429,13 +336,13 @@ class TestMetadataWarnings:
 
 class TestFilamentColor:
     def test_invalid_color(self, tmp_path: Path) -> None:
-        si = _MINIMAL_SLICE_INFO.replace('color="#F2754E"', 'color="not-a-color"')
-        path = _build_valid_3mf(tmp_path, slice_info=si)
+        si = MINIMAL_SLICE_INFO.replace('color="#F2754E"', 'color="not-a-color"')
+        path = build_valid_3mf(tmp_path, slice_info=si)
         result = validate_3mf(path)
         assert any(f.code == "W004" for f in result.warnings)
 
     def test_valid_color_passes(self, tmp_path: Path) -> None:
-        path = _build_valid_3mf(tmp_path)
+        path = build_valid_3mf(tmp_path)
         result = validate_3mf(path)
         assert not any(f.code == "W004" for f in result.findings)
 
@@ -454,7 +361,7 @@ class TestProgressMarkers:
             "M73 L1\n"
             "M991 S0 P1\n"
         )
-        path = _build_valid_3mf(tmp_path, gcode=gcode)
+        path = build_valid_3mf(tmp_path, gcode=gcode)
         result = validate_3mf(path)
         assert any(f.code == "W007" for f in result.warnings)
 
@@ -466,7 +373,7 @@ class TestProgressMarkers:
             "M73 L1\nM73 P100\n"
             "M991 S0 P1\n"
         )
-        path = _build_valid_3mf(tmp_path, gcode=gcode)
+        path = build_valid_3mf(tmp_path, gcode=gcode)
         result = validate_3mf(path)
         assert any(f.code == "W008" for f in result.warnings)
 
@@ -486,7 +393,7 @@ class TestMonotonicity:
             "M73 L3\nM73 P66 R1\nM991 S0 P3\n"
             "M73 L2\nM73 P100 R0\nM991 S0 P2\n"
         )
-        path = _build_valid_3mf(tmp_path, gcode=gcode)
+        path = build_valid_3mf(tmp_path, gcode=gcode)
         result = validate_3mf(path)
         assert any(f.code == "W009" for f in result.warnings)
 
@@ -500,7 +407,7 @@ class TestCLIValidate:
     def test_valid_archive_exit_0(self, tmp_path: Path) -> None:
         from bambox.cli import main
 
-        path = _build_valid_3mf(tmp_path)
+        path = build_valid_3mf(tmp_path)
         # Should not raise SystemExit
         main(["validate", str(path)])
 
@@ -515,7 +422,7 @@ class TestCLIValidate:
     def test_json_output(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         from bambox.cli import main
 
-        path = _build_valid_3mf(tmp_path)
+        path = build_valid_3mf(tmp_path)
         main(["validate", "--json", str(path)])
         out = capsys.readouterr().out
         data = json.loads(out)
@@ -526,8 +433,8 @@ class TestCLIValidate:
     def test_strict_fails_on_warnings(self, tmp_path: Path) -> None:
         from bambox.cli import main
 
-        si = _MINIMAL_SLICE_INFO.replace('value="C12"', 'value=""')
-        path = _build_valid_3mf(tmp_path, slice_info=si)
+        si = MINIMAL_SLICE_INFO.replace('value="C12"', 'value=""')
+        path = build_valid_3mf(tmp_path, slice_info=si)
         with pytest.raises(SystemExit, match="1"):
             main(["validate", "--strict", str(path)])
 
@@ -556,7 +463,7 @@ class TestCompatiblePrinters:
                 "print_compatible_printers": ["Bambu Lab X1 Carbon 0.4 nozzle"] * 5,
             }
         )
-        path = _build_valid_3mf(tmp_path, settings=settings)
+        path = build_valid_3mf(tmp_path, settings=settings)
         result = validate_3mf(path)
         assert any(f.code == "W005" for f in result.warnings)
 
@@ -577,7 +484,7 @@ class TestCompatiblePrinters:
                 ],
             }
         )
-        path = _build_valid_3mf(tmp_path, settings=settings)
+        path = build_valid_3mf(tmp_path, settings=settings)
         result = validate_3mf(path)
         assert not any(f.code == "W005" for f in result.findings)
 
@@ -600,7 +507,7 @@ class TestPrinterModel:
                 "printer_model": "",
             }
         )
-        path = _build_valid_3mf(tmp_path, settings=settings)
+        path = build_valid_3mf(tmp_path, settings=settings)
         result = validate_3mf(path)
         assert any(f.code == "W006" for f in result.warnings)
 
@@ -616,7 +523,7 @@ class TestPrinterModel:
                 "printer_model": "Bambu Lab P1S",
             }
         )
-        path = _build_valid_3mf(tmp_path, settings=settings)
+        path = build_valid_3mf(tmp_path, settings=settings)
         result = validate_3mf(path)
         assert not any(f.code == "W006" for f in result.findings)
 
@@ -630,7 +537,7 @@ class TestRecommendedThumbnails:
     def test_missing_top_and_pick(self, tmp_path: Path) -> None:
         """Archive without top_1.png and pick_1.png triggers W010."""
         out = tmp_path / "test.gcode.3mf"
-        gcode_bytes = _MINIMAL_GCODE.encode()
+        gcode_bytes = MINIMAL_GCODE.encode()
         md5 = hashlib.md5(gcode_bytes).hexdigest().upper()
         with zipfile.ZipFile(out, "w") as zf:
             zf.writestr("[Content_Types].xml", "<Types/>")
@@ -640,8 +547,8 @@ class TestRecommendedThumbnails:
             zf.writestr("Metadata/plate_1.gcode.md5", md5)
             zf.writestr("Metadata/model_settings.config", "{}")
             zf.writestr("Metadata/_rels/model_settings.config.rels", "<Relationships/>")
-            zf.writestr("Metadata/slice_info.config", _MINIMAL_SLICE_INFO)
-            zf.writestr("Metadata/project_settings.config", _MINIMAL_SETTINGS)
+            zf.writestr("Metadata/slice_info.config", MINIMAL_SLICE_INFO)
+            zf.writestr("Metadata/project_settings.config", MINIMAL_SETTINGS)
             zf.writestr("Metadata/plate_1.json", "{}")
             zf.writestr("Metadata/plate_1.png", b"\x89PNG\r\n\x1a\n")
             zf.writestr("Metadata/plate_no_light_1.png", b"\x89PNG\r\n\x1a\n")
@@ -652,7 +559,7 @@ class TestRecommendedThumbnails:
         assert len(w010) == 2
 
     def test_with_thumbnails_passes(self, tmp_path: Path) -> None:
-        path = _build_valid_3mf(tmp_path)
+        path = build_valid_3mf(tmp_path)
         result = validate_3mf(path)
         assert not any(f.code == "W010" for f in result.findings)
 
@@ -665,15 +572,15 @@ class TestRecommendedThumbnails:
 class TestTimeSync:
     def test_divergent_time_detected(self, tmp_path: Path) -> None:
         """M73 R2 (2 min) vs prediction 7200s (120 min) should trigger W011."""
-        gcode = _MINIMAL_GCODE  # has M73 P0 R2 at start
-        si = _MINIMAL_SLICE_INFO.replace('value="150"', 'value="7200"')
-        path = _build_valid_3mf(tmp_path, gcode=gcode, slice_info=si)
+        gcode = MINIMAL_GCODE  # has M73 P0 R2 at start
+        si = MINIMAL_SLICE_INFO.replace('value="150"', 'value="7200"')
+        path = build_valid_3mf(tmp_path, gcode=gcode, slice_info=si)
         result = validate_3mf(path)
         assert any(f.code == "W011" for f in result.warnings)
 
     def test_aligned_time_passes(self, tmp_path: Path) -> None:
         """M73 R2 (2 min = 120s) vs prediction 150s — within tolerance."""
-        path = _build_valid_3mf(tmp_path)
+        path = build_valid_3mf(tmp_path)
         result = validate_3mf(path)
         assert not any(f.code == "W011" for f in result.findings)
 
@@ -713,13 +620,13 @@ G1 X20 Y20 E2 F600
 
 class TestMultiFilamentE013:
     def test_proper_multi_filament_passes(self, tmp_path: Path) -> None:
-        path = _build_valid_3mf(tmp_path, gcode=_MULTI_FILAMENT_GCODE)
+        path = build_valid_3mf(tmp_path, gcode=_MULTI_FILAMENT_GCODE)
         result = validate_3mf(path)
         assert not any(f.code == "E013" for f in result.findings)
 
     def test_single_filament_no_check(self, tmp_path: Path) -> None:
         """Single-filament gcode should not trigger E013."""
-        path = _build_valid_3mf(tmp_path)
+        path = build_valid_3mf(tmp_path)
         result = validate_3mf(path)
         assert not any(f.code == "E013" for f in result.findings)
 
@@ -759,7 +666,7 @@ M991 S0 P2
 M73 P100 R0
 G1 X20 Y20 E2 F600
 """
-        path = _build_valid_3mf(tmp_path, gcode=gcode)
+        path = build_valid_3mf(tmp_path, gcode=gcode)
         result = validate_3mf(path)
         assert any(f.code == "E014" for f in result.errors)
 
@@ -793,13 +700,13 @@ M991 S0 P2
 M73 P100 R0
 G1 X20 Y20 E2 F600
 """
-        path = _build_valid_3mf(tmp_path, gcode=gcode)
+        path = build_valid_3mf(tmp_path, gcode=gcode)
         result = validate_3mf(path)
         assert not any(f.code == "E014" for f in result.findings)
 
     def test_t_inside_block_ok(self, tmp_path: Path) -> None:
         """T commands inside M620/M621 blocks should not trigger E014."""
-        path = _build_valid_3mf(tmp_path, gcode=_MULTI_FILAMENT_GCODE)
+        path = build_valid_3mf(tmp_path, gcode=_MULTI_FILAMENT_GCODE)
         result = validate_3mf(path)
         assert not any(f.code == "E014" for f in result.findings)
 
@@ -821,12 +728,12 @@ class TestNozzleTempRange:
                 "filament_max_volumetric_speed": ["12"] * 5,
             }
         )
-        path = _build_valid_3mf(tmp_path, settings=settings)
+        path = build_valid_3mf(tmp_path, settings=settings)
         result = validate_3mf(path)
         assert any(f.code == "W012" for f in result.warnings)
 
     def test_valid_nozzle_temp_passes(self, tmp_path: Path) -> None:
-        path = _build_valid_3mf(tmp_path)
+        path = build_valid_3mf(tmp_path)
         result = validate_3mf(path)
         assert not any(f.code == "W012" for f in result.findings)
 
@@ -849,7 +756,7 @@ class TestBedTempRange:
                 "hot_plate_temp": ["150", "60", "60", "60", "60"],
             }
         )
-        path = _build_valid_3mf(tmp_path, settings=settings)
+        path = build_valid_3mf(tmp_path, settings=settings)
         result = validate_3mf(path)
         assert any(f.code == "W013" for f in result.warnings)
 
@@ -866,12 +773,12 @@ class TestBedTempRange:
                 "filament_tower_interface_print_temp": ["-1"] * 5,
             }
         )
-        path = _build_valid_3mf(tmp_path, settings=settings)
+        path = build_valid_3mf(tmp_path, settings=settings)
         result = validate_3mf(path)
         assert not any(f.code == "W013" for f in result.findings)
 
     def test_valid_bed_temp_passes(self, tmp_path: Path) -> None:
-        path = _build_valid_3mf(tmp_path)
+        path = build_valid_3mf(tmp_path)
         result = validate_3mf(path)
         assert not any(f.code == "W013" for f in result.findings)
 
@@ -894,7 +801,7 @@ class TestFlushVolumesMatrix:
                 "flush_volumes_matrix": [0, 1, 2],
             }
         )
-        path = _build_valid_3mf(tmp_path, settings=settings)
+        path = build_valid_3mf(tmp_path, settings=settings)
         result = validate_3mf(path)
         assert any(f.code == "W014" for f in result.warnings)
 
@@ -910,7 +817,7 @@ class TestFlushVolumesMatrix:
                 "flush_volumes_matrix": [0, 1, 2, 3],
             }
         )
-        path = _build_valid_3mf(tmp_path, settings=settings)
+        path = build_valid_3mf(tmp_path, settings=settings)
         result = validate_3mf(path)
         assert not any(f.code == "W014" for f in result.findings)
 
@@ -923,53 +830,53 @@ class TestFlushVolumesMatrix:
 class TestCompare3mf:
     def test_identical_archives(self, tmp_path: Path) -> None:
         (tmp_path / "a").mkdir()
-        a = _build_valid_3mf(tmp_path / "a")
+        a = build_valid_3mf(tmp_path / "a")
         (tmp_path / "b").mkdir()
-        b = _build_valid_3mf(tmp_path / "b")
+        b = build_valid_3mf(tmp_path / "b")
         result = compare_3mf(a, b)
         assert result.valid
 
     def test_different_filament_types(self, tmp_path: Path) -> None:
         (tmp_path / "a").mkdir()
         (tmp_path / "b").mkdir()
-        a = _build_valid_3mf(tmp_path / "a")
-        si_petg = _MINIMAL_SLICE_INFO.replace('type="PLA"', 'type="PETG"')
-        b = _build_valid_3mf(tmp_path / "b", slice_info=si_petg)
+        a = build_valid_3mf(tmp_path / "a")
+        si_petg = MINIMAL_SLICE_INFO.replace('type="PLA"', 'type="PETG"')
+        b = build_valid_3mf(tmp_path / "b", slice_info=si_petg)
         result = compare_3mf(a, b)
         assert any(f.code == "C001" for f in result.errors)
 
     def test_divergent_print_time(self, tmp_path: Path) -> None:
         (tmp_path / "a").mkdir()
         (tmp_path / "b").mkdir()
-        a = _build_valid_3mf(tmp_path / "a")
-        si_long = _MINIMAL_SLICE_INFO.replace('value="150"', 'value="15000"')
-        b = _build_valid_3mf(tmp_path / "b", slice_info=si_long)
+        a = build_valid_3mf(tmp_path / "a")
+        si_long = MINIMAL_SLICE_INFO.replace('value="150"', 'value="15000"')
+        b = build_valid_3mf(tmp_path / "b", slice_info=si_long)
         result = compare_3mf(a, b)
         assert any(f.code == "C002" for f in result.errors)
 
     def test_divergent_weight(self, tmp_path: Path) -> None:
         (tmp_path / "a").mkdir()
         (tmp_path / "b").mkdir()
-        a = _build_valid_3mf(tmp_path / "a")
-        si_heavy = _MINIMAL_SLICE_INFO.replace('value="5.00"', 'value="50.00"')
-        b = _build_valid_3mf(tmp_path / "b", slice_info=si_heavy)
+        a = build_valid_3mf(tmp_path / "a")
+        si_heavy = MINIMAL_SLICE_INFO.replace('value="5.00"', 'value="50.00"')
+        b = build_valid_3mf(tmp_path / "b", slice_info=si_heavy)
         result = compare_3mf(a, b)
         assert any(f.code == "C003" for f in result.errors)
 
     def test_different_printer_model(self, tmp_path: Path) -> None:
         (tmp_path / "a").mkdir()
         (tmp_path / "b").mkdir()
-        a = _build_valid_3mf(tmp_path / "a")
-        si_x1 = _MINIMAL_SLICE_INFO.replace('value="C12"', 'value="C11"')
-        b = _build_valid_3mf(tmp_path / "b", slice_info=si_x1)
+        a = build_valid_3mf(tmp_path / "a")
+        si_x1 = MINIMAL_SLICE_INFO.replace('value="C12"', 'value="C11"')
+        b = build_valid_3mf(tmp_path / "b", slice_info=si_x1)
         result = compare_3mf(a, b)
         assert any(f.code == "C005" for f in result.errors)
 
     def test_different_tool_changes(self, tmp_path: Path) -> None:
         (tmp_path / "a").mkdir()
         (tmp_path / "b").mkdir()
-        a = _build_valid_3mf(tmp_path / "a", gcode=_MULTI_FILAMENT_GCODE)
-        b = _build_valid_3mf(tmp_path / "b")
+        a = build_valid_3mf(tmp_path / "a", gcode=_MULTI_FILAMENT_GCODE)
+        b = build_valid_3mf(tmp_path / "b")
         result = compare_3mf(a, b)
         assert any(f.code == "C004" for f in result.errors)
 
@@ -985,8 +892,8 @@ class TestCLIReference:
 
         (tmp_path / "a").mkdir()
         (tmp_path / "b").mkdir()
-        a = _build_valid_3mf(tmp_path / "a")
-        b = _build_valid_3mf(tmp_path / "b")
+        a = build_valid_3mf(tmp_path / "a")
+        b = build_valid_3mf(tmp_path / "b")
         # Should not raise
         main(["validate", str(a), "--reference", str(b)])
 
@@ -995,8 +902,8 @@ class TestCLIReference:
 
         (tmp_path / "a").mkdir()
         (tmp_path / "b").mkdir()
-        a = _build_valid_3mf(tmp_path / "a")
-        b = _build_valid_3mf(tmp_path / "b")
+        a = build_valid_3mf(tmp_path / "a")
+        b = build_valid_3mf(tmp_path / "b")
         main(["validate", "--json", str(a), "--reference", str(b)])
         out = capsys.readouterr().out
         data = json.loads(out)
@@ -1006,6 +913,6 @@ class TestCLIReference:
     def test_reference_missing_file(self, tmp_path: Path) -> None:
         from bambox.cli import main
 
-        a = _build_valid_3mf(tmp_path)
+        a = build_valid_3mf(tmp_path)
         with pytest.raises(SystemExit, match="1"):
             main(["validate", str(a), "--reference", str(tmp_path / "nope.3mf")])


### PR DESCRIPTION
## Summary
- Create `tests/shared_fixtures.py` with shared test constants and `build_valid_3mf()` helper
- Remove ~90 lines of duplication between `test_validate.py` and `test_release_readiness.py`
- Add `tests/` to pytest `pythonpath` in pyproject.toml

Closes #161

## Test plan
- [x] All 574 tests pass
- [x] Lint, format, type checks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)