### PR TITLE
Improve FFI safety: track symbol resolution and expand null checks

### DIFF
--- a/bridge/shim/shim.cpp
+++ b/bridge/shim/shim.cpp
@@ -138,9 +138,17 @@ static fn_start_print               fp_start_print = nullptr;
 // Helper
 // ---------------------------------------------------------------------------
 
+/// Number of successfully resolved symbols after bambu_shim_load().
+static int g_resolved_count = 0;
+
+/// Total number of symbols that bambu_shim_load() attempts to resolve.
+static int g_expected_count = 0;
+
 template<typename T>
 static T load_fn(const char* name) {
     void* ptr = dlsym(g_lib, name);
+    g_expected_count++;
+    if (ptr) g_resolved_count++;
     return reinterpret_cast<T>(ptr);
 }
 
@@ -155,6 +163,9 @@ int bambu_shim_load(const char* lib_path) {
 
     g_lib = dlopen(lib_path, RTLD_LAZY);
     if (!g_lib) return -1;
+
+    g_resolved_count = 0;
+    g_expected_count = 0;
 
     fp_create_agent    = load_fn<fn_create_agent>("bambu_network_create_agent");
     fp_destroy_agent   = load_fn<fn_destroy_agent>("bambu_network_destroy_agent");
@@ -181,12 +192,24 @@ int bambu_shim_load(const char* lib_path) {
     fp_start_sub       = load_fn<fn_start_subscribe>("bambu_network_start_subscribe");
     fp_start_print     = load_fn<fn_start_print>("bambu_network_start_print");
 
-    if (!fp_create_agent || !fp_change_user || !fp_connect_server) {
+    // All core functions must resolve — fail early rather than segfault later.
+    if (!fp_create_agent || !fp_destroy_agent || !fp_change_user ||
+        !fp_connect_server || !fp_start || !fp_set_machine ||
+        !fp_send_msg || !fp_start_sub || !fp_set_message_cb ||
+        !fp_set_server_cb || !fp_start_print) {
         dlclose(g_lib);
         g_lib = nullptr;
         return -2;
     }
     return 0;
+}
+
+int bambu_shim_resolved_count() {
+    return g_resolved_count;
+}
+
+int bambu_shim_expected_count() {
+    return g_expected_count;
 }
 
 const char* bambu_shim_load_error() {

--- a/bridge/src/agent.rs
+++ b/bridge/src/agent.rs
@@ -219,6 +219,17 @@ impl BambuAgent {
             return Err(format!("failed to load library: {err}"));
         }
 
+        // Log symbol resolution stats from the shim
+        let resolved = unsafe { ffi::bambu_shim_resolved_count() };
+        let expected = unsafe { ffi::bambu_shim_expected_count() };
+        if resolved < expected {
+            eprintln!(
+                "warning: shim resolved {resolved}/{expected} symbols — some features may be unavailable"
+            );
+        } else {
+            eprintln!("shim: resolved all {resolved}/{expected} symbols");
+        }
+
         // Set SSL cert env vars (same as C++ bridge) — needed for uploads
         if std::env::var("CURL_CA_BUNDLE").is_err() {
             std::env::set_var("CURL_CA_BUNDLE", "/etc/ssl/certs/ca-certificates.crt");

--- a/bridge/src/ffi.rs
+++ b/bridge/src/ffi.rs
@@ -139,6 +139,10 @@ extern "C" {
         ctx: *mut c_void,
     ) -> c_int;
 
+    // Symbol resolution diagnostics
+    pub fn bambu_shim_resolved_count() -> c_int;
+    pub fn bambu_shim_expected_count() -> c_int;
+
     // Print
     pub fn bambu_shim_start_print(
         agent: *mut c_void,

--- a/changes/162.misc
+++ b/changes/162.misc
@@ -1,0 +1,1 @@
+Improve FFI safety in C++ shim: track symbol resolution counts, expand null-check validation to 11 critical function pointers, and log resolution diagnostics on load.


### PR DESCRIPTION
## Summary
- Add symbol resolution counting (`g_resolved_count`/`g_expected_count`) to the C++ shim's `load_fn` template
- Expand critical null-check validation from 3 to 11 function pointers in `bambu_shim_load()`
- Expose `bambu_shim_resolved_count()` and `bambu_shim_expected_count()` query functions via FFI
- Log symbol resolution diagnostics in Rust `BambuAgent::new()` after successful library load

Closes #162

## Test plan
- [ ] CI bridge build passes on Linux
- [ ] Python test suite unaffected (no Python changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)