### PR TITLE
Add install-test.sh script for TestPyPI dev builds

### DIFF
--- a/changes/+install-test.misc
+++ b/changes/+install-test.misc
@@ -1,0 +1,1 @@
+Add ``scripts/install-test.sh`` to install the latest dev build from TestPyPI.

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Install the latest dev build of bambox from TestPyPI.
+# Usage: ./scripts/install-test.sh
+set -euo pipefail
+
+# Find the latest dev version from the TestPyPI JSON API
+LATEST=$(python3 -c "
+import json, urllib.request
+data = json.load(urllib.request.urlopen('https://test.pypi.org/pypi/bambox/json'))
+devs = [v for v in data['releases'] if '.dev' in v]
+devs.sort(key=lambda v: data['releases'][v][0]['upload_time'] if data['releases'][v] else '')
+print(devs[-1])
+")
+
+if [ -z "$LATEST" ]; then
+    echo "Could not find a dev version on TestPyPI"
+    exit 1
+fi
+
+echo "Installing bambox==${LATEST} from TestPyPI..."
+pip install --index-url https://test.pypi.org/simple/ \
+    --extra-index-url https://pypi.org/simple/ \
+    "bambox==${LATEST}"
+
+echo ""
+bambox --version


### PR DESCRIPTION
## Summary
- Add `scripts/install-test.sh` to install the latest `.dev` build of bambox from TestPyPI
- Same pattern as estampo's `scripts/install-test.sh`

## Test plan
- [ ] CI passes (no Python source changes)
- [ ] Script is executable

🤖 Generated with [Claude Code](https://claude.com/claude-code)