### PR TITLE
Fix status -w cache staleness when printer sends heartbeats

### DIFF
--- a/bridge/src/server.rs
+++ b/bridge/src/server.rs
@@ -612,23 +612,33 @@ pub fn spawn_cache_updater(state: SharedState) {
             // Update cache for each device that sent messages
             let mut cache = state.cache.write().unwrap();
             for (dev_id, msg) in best_per_device {
-                // Only cache messages that look like full status (have gcode_state)
-                if msg.payload.len() < 100 || !msg.payload.contains("gcode_state") {
-                    continue;
+                // Full status message — update both payload and timestamp
+                if msg.payload.len() >= 100 && msg.payload.contains("gcode_state") {
+                    if let Ok(payload) = serde_json::from_str::<serde_json::Value>(&msg.payload) {
+                        tracing::trace!(
+                            device_id = %dev_id,
+                            payload_len = msg.payload.len(),
+                            "cache updated by background task"
+                        );
+                        cache.insert(
+                            dev_id,
+                            DeviceStatus {
+                                payload,
+                                updated_at: Instant::now(),
+                            },
+                        );
+                        continue;
+                    }
                 }
-                if let Ok(payload) = serde_json::from_str::<serde_json::Value>(&msg.payload) {
+                // Heartbeat or partial message — keep existing payload but refresh
+                // the timestamp so the cache doesn't go stale while subscribed.
+                if let Some(entry) = cache.get_mut(&dev_id) {
                     tracing::trace!(
                         device_id = %dev_id,
                         payload_len = msg.payload.len(),
-                        "cache updated by background task"
+                        "cache timestamp refreshed by heartbeat"
                     );
-                    cache.insert(
-                        dev_id,
-                        DeviceStatus {
-                            payload,
-                            updated_at: Instant::now(),
-                        },
-                    );
+                    entry.updated_at = Instant::now();
                 }
             }
         }

--- a/changes/+status-watch-cache.bugfix
+++ b/changes/+status-watch-cache.bugfix
@@ -1,0 +1,1 @@
+Fix ``status -w`` updating every ~9s instead of 1s when printer is idle.


### PR DESCRIPTION
## Summary
- When the printer is idle/finished, MQTT pushes short heartbeat messages without `gcode_state`
- The cache updater was filtering these out (`payload.len() < 100 || !contains("gcode_state")`)
- Cache went stale after 10s, every HTTP request fell through to `subscribe_and_pushall` (~9s round-trip)
- Fix: heartbeat messages now refresh the cache `updated_at` timestamp without replacing the payload, keeping the fast cache-hit path alive

## Test plan
- [ ] CI passes (bridge builds + Python tests)
- [ ] Manual: `bambox status -w` should update every ~1s even when printer is idle/finished

🤖 Generated with [Claude Code](https://claude.com/claude-code)