### PR TITLE
Trigger bridge builds on push to main

### DIFF
--- a/.github/workflows/build-bridge.yml
+++ b/.github/workflows/build-bridge.yml
@@ -3,6 +3,9 @@ name: Build bridge binaries
 on:
   push:
     tags: ['v*']
+    branches: [main]
+    paths:
+      - 'bridge/**'
   pull_request:
     paths:
       - 'bridge/**'

--- a/changes/+bridge-ci-trigger.misc
+++ b/changes/+bridge-ci-trigger.misc
@@ -1,0 +1,1 @@
+Build bridge binaries on push to main (not just PRs and tags) so ``install-dev.sh`` always picks up the latest.


### PR DESCRIPTION
## Summary
- Add `push: branches: [main]` with `paths: [bridge/**]` to `build-bridge.yml`
- Previously merging bridge changes to main didn't produce new artifacts, so `install-dev.sh` downloaded stale binaries

## Test plan
- [ ] CI passes
- [ ] After merge, pushing bridge changes to main triggers a bridge build

🤖 Generated with [Claude Code](https://claude.com/claude-code)