### PR TITLE
Fix cancel command: QoS 1 and missing param field

### DIFF
--- a/bridge/src/agent.rs
+++ b/bridge/src/agent.rs
@@ -503,19 +503,25 @@ impl BambuAgent {
         Ok(())
     }
 
-    /// Send an MQTT message to a device. Tries both send functions.
+    /// Send an MQTT message to a device via cloud (QoS 1).
+    ///
+    /// Uses `send_message` (cloud path) matching BambuStudio's
+    /// `cloud_publish_json`.  Falls back to `send_message_to_printer`
+    /// (LAN path) only if the cloud call fails.
     pub fn send_message(&self, device_id: &str, json: &str) -> Result<i32, String> {
         let dev = to_cstring(device_id)?;
         let msg = to_cstring(json)?;
+        // QoS 1 — BambuStudio sends all print commands at QoS 1
         let mut ret =
-            unsafe { ffi::bambu_shim_send_message(self.agent, dev.as_ptr(), msg.as_ptr(), 0) };
+            unsafe { ffi::bambu_shim_send_message(self.agent, dev.as_ptr(), msg.as_ptr(), 1) };
         if ret != 0 {
+            tracing::debug!(ret, "send_message (cloud) failed, trying send_message_to_printer");
             ret = unsafe {
                 ffi::bambu_shim_send_message_to_printer(
                     self.agent,
                     dev.as_ptr(),
                     msg.as_ptr(),
-                    0,
+                    1,
                     0,
                 )
             };

--- a/bridge/src/main.rs
+++ b/bridge/src/main.rs
@@ -495,8 +495,8 @@ async fn main() {
                 fast_exit(1);
             }
 
-            // Send the MQTT stop command
-            let stop_cmd = r#"{"print":{"command":"stop","sequence_id":"0"}}"#;
+            // Send the MQTT stop command (matches BambuStudio's command_task_abort)
+            let stop_cmd = r#"{"print":{"command":"stop","param":"","sequence_id":"0"}}"#;
             let ret = match agent.send_message(&device_id, stop_cmd) {
                 Ok(r) => r,
                 Err(e) => {

--- a/bridge/src/server.rs
+++ b/bridge/src/server.rs
@@ -315,8 +315,8 @@ async fn cancel_print(
     // Set the atomic cancel flag so any in-flight upload aborts immediately
     let _ = state.handle.cancel_print().await;
 
-    // Also send the MQTT stop command to the printer
-    let stop_cmd = r#"{"print":{"command":"stop","sequence_id":"0"}}"#;
+    // Send the MQTT stop command matching BambuStudio's command_task_abort()
+    let stop_cmd = r#"{"print":{"command":"stop","param":"","sequence_id":"0"}}"#;
     let ret = state
         .handle
         .send_message(device_id.clone(), stop_cmd.to_string())

--- a/changes/180.bugfix
+++ b/changes/180.bugfix
@@ -1,0 +1,1 @@
+Fix cancel/stop command: use QoS 1 and add missing ``param`` field to match BambuStudio's MQTT protocol.


### PR DESCRIPTION
## Summary
- Change `send_message` from QoS 0 to QoS 1, matching BambuStudio's `cloud_publish_json`
- Add missing `"param":""` field to stop command JSON, matching BambuStudio's `command_task_abort()`
- Add debug logging when cloud send falls back to LAN path

Found by comparing against BambuStudio `DeviceManager.cpp` — our stop command was missing a field and using unreliable delivery (QoS 0 = fire-and-forget).

## Test plan
- [ ] CI bridge builds pass
- [ ] `bambox cancel` with daemon running sends stop successfully
- [ ] Printer actually stops a running/paused print

🤖 Generated with [Claude Code](https://claude.com/claude-code)