### PR TITLE
Fix send_message FFI: add missing flag parameter

### DIFF
--- a/bridge/shim/shim.cpp
+++ b/bridge/shim/shim.cpp
@@ -98,7 +98,7 @@ typedef int (*fn_set_get_country_code_fn)(void*, GetCountryCodeFn);
 typedef int (*fn_set_on_user_login_fn)(void*, OnUserLoginFn);
 typedef int (*fn_set_on_subscribe_failure_fn)(void*, GetSubscribeFailureFn);
 typedef int (*fn_set_extra_http_header)(void*, std::map<std::string, std::string>);
-typedef int (*fn_send_message)(void*, std::string, std::string, int);
+typedef int (*fn_send_message)(void*, std::string, std::string, int, int);
 typedef int (*fn_send_message_to_printer)(void*, std::string, std::string, int, int);
 typedef int (*fn_start_subscribe)(void*, std::string);
 typedef int (*fn_start_print)(void*, PrintParams, OnUpdateStatusFn, WasCancelledFn, OnWaitFn);
@@ -294,7 +294,8 @@ int bambu_shim_start_subscribe(void* agent, const char* module) {
 
 int bambu_shim_send_message(void* agent, const char* dev_id, const char* json, int qos) {
     if (!fp_send_msg) return -1;
-    return fp_send_msg(agent, std::string(dev_id), std::string(json), qos);
+    // flag=0 (no signing/encryption) — matches BambuStudio's default
+    return fp_send_msg(agent, std::string(dev_id), std::string(json), qos, 0);
 }
 
 int bambu_shim_send_message_to_printer(

--- a/changes/181.bugfix
+++ b/changes/181.bugfix
@@ -1,0 +1,1 @@
+Fix ``send_message`` FFI signature: add missing ``flag`` parameter, fixing cancel and other MQTT commands returning -2.


### PR DESCRIPTION
## Summary
- `bambu_network_send_message` takes 5 parameters `(agent, dev_id, json, qos, flag)` but our shim typedef only declared 4 (missing `flag`)
- This caused the SDK to read garbage from the stack as the flag value, returning -2 on cloud send_message calls
- Cancel/stop commands were silently failing because of this

Found by comparing our `shim.cpp` typedef against BambuStudio's `NetworkAgent.hpp` `func_send_message` signature.

## Test plan
- [ ] CI bridge builds pass
- [ ] `curl -X POST http://localhost:8765/cancel/<device_id>` returns `{"sent":true}` instead of -2 error
- [ ] Cancel actually stops a paused/running print

🤖 Generated with [Claude Code](https://claude.com/claude-code)