### PR TITLE
feat: bridge version check on daemon connect

### DIFF
--- a/bridge/src/main.rs
+++ b/bridge/src/main.rs
@@ -514,7 +514,11 @@ async fn main() {
             restore_stdout();
 
             let agent_handle = handle::spawn_agent_thread(agent);
-            let state = server::AppState::new(agent_handle, printers.clone());
+            let state = server::AppState::new(
+                agent_handle,
+                printers.clone(),
+                cli.plugin_version.clone(),
+            );
             server::spawn_cache_updater(state.clone());
 
             // Pre-subscribe to all configured printers so the cache is warm

--- a/bridge/src/server.rs
+++ b/bridge/src/server.rs
@@ -25,6 +25,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::handle::AgentHandle;
 
+pub const API_VERSION: u32 = 1;
+
 // ---------------------------------------------------------------------------
 // Shared state
 // ---------------------------------------------------------------------------
@@ -55,12 +57,18 @@ pub struct AppState {
     pub printers: Vec<PrinterEntry>,
     /// When the daemon started.
     pub started_at: Instant,
+    /// Bambu plugin version (e.g. "02.05.00.00").
+    pub plugin_version: String,
 }
 
 pub type SharedState = Arc<AppState>;
 
 impl AppState {
-    pub fn new(handle: AgentHandle, printers: Vec<(String, String)>) -> SharedState {
+    pub fn new(
+        handle: AgentHandle,
+        printers: Vec<(String, String)>,
+        plugin_version: String,
+    ) -> SharedState {
         Arc::new(Self {
             handle,
             cache: RwLock::new(HashMap::new()),
@@ -70,6 +78,7 @@ impl AppState {
                 .map(|(name, serial)| PrinterEntry { name, serial })
                 .collect(),
             started_at: Instant::now(),
+            plugin_version,
         })
     }
 }
@@ -85,6 +94,9 @@ pub struct HealthResponse {
     pub mqtt_connected: bool,
     pub uptime_secs: u64,
     pub cached_devices: Vec<String>,
+    pub bridge_version: String,
+    pub api_version: u32,
+    pub plugin_version: String,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -146,6 +158,9 @@ async fn health(State(state): State<SharedState>) -> Json<HealthResponse> {
         mqtt_connected,
         uptime_secs: state.started_at.elapsed().as_secs(),
         cached_devices,
+        bridge_version: env!("CARGO_PKG_VERSION").into(),
+        api_version: API_VERSION,
+        plugin_version: state.plugin_version.clone(),
     })
 }
 
@@ -690,6 +705,7 @@ pub fn mock_state_with_printers(
             .map(|(name, serial)| PrinterEntry { name, serial })
             .collect(),
         started_at: Instant::now(),
+        plugin_version: "02.05.00.00".into(),
     });
     state
 }
@@ -764,6 +780,9 @@ mod tests {
         assert_eq!(body.status, "ok");
         assert!(!body.mqtt_connected);
         assert!(body.cached_devices.is_empty());
+        assert_eq!(body.bridge_version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(body.api_version, API_VERSION);
+        assert_eq!(body.plugin_version, "02.05.00.00");
     }
 
     #[tokio::test]

--- a/changes/+bridge-version-check.feature
+++ b/changes/+bridge-version-check.feature
@@ -1,0 +1,1 @@
+Bridge version check: /health endpoint now reports bridge_version, api_version, and plugin_version; Python client validates API compatibility on daemon connect.

--- a/src/bambox/bridge.py
+++ b/src/bambox/bridge.py
@@ -32,6 +32,7 @@ def _xml_ns(root: ET.Element) -> str:
 
 
 DOCKER_IMAGE = "estampo/bambox-bridge:bambu-02.05.00.00"
+EXPECTED_API_VERSION = 1
 
 # ---------------------------------------------------------------------------
 # Credentials
@@ -462,6 +463,41 @@ def _daemon_ping() -> bool:
         return False
 
 
+def _check_daemon_version() -> None:
+    """Check bridge daemon version compatibility via /health endpoint.
+
+    Raises RuntimeError if the bridge API version is incompatible.
+    Logs a warning if the bridge version cannot be determined (old bridge).
+    """
+    import urllib.request
+
+    try:
+        req = urllib.request.Request(f"{DAEMON_URL}/health", method="GET")
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            data = json.loads(resp.read())
+    except Exception:
+        log.warning("Could not query bridge version — skipping compatibility check")
+        return
+
+    api_version = data.get("api_version")
+    bridge_version = data.get("bridge_version", "unknown")
+
+    if api_version is None:
+        log.warning(
+            "Bridge daemon does not report api_version — "
+            "update with: pip install -U bambox  or  docker pull %s",
+            DOCKER_IMAGE,
+        )
+        return
+
+    if api_version != EXPECTED_API_VERSION:
+        raise RuntimeError(
+            f"Bridge API version mismatch: daemon reports v{api_version} "
+            f"(bridge {bridge_version}), but bambox expects v{EXPECTED_API_VERSION}. "
+            f"Update the bridge: pip install -U bambox  or  docker pull {DOCKER_IMAGE}"
+        )
+
+
 def _start_daemon(token_file: Path, *, verbose: bool = False) -> bool:
     """Start the bridge daemon in the background.  Returns True if started."""
     binary = _find_local_bridge()
@@ -494,9 +530,13 @@ def _start_daemon(token_file: Path, *, verbose: bool = False) -> bool:
 def _ensure_daemon(token_file: Path, *, verbose: bool = False) -> bool:
     """Ensure a daemon is running.  Returns True if available."""
     if _daemon_ping():
+        _check_daemon_version()
         return True
     log.info("No daemon running, starting one...")
-    return _start_daemon(token_file, verbose=verbose)
+    if _start_daemon(token_file, verbose=verbose):
+        _check_daemon_version()
+        return True
+    return False
 
 
 def query_status_daemon(device_id: str) -> dict:

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -13,7 +13,9 @@ from unittest.mock import patch
 import pytest
 
 from bambox.bridge import (
+    EXPECTED_API_VERSION,
     _build_ams_mapping,
+    _check_daemon_version,
     _cloud_print_impl,
     _find_local_bridge,
     _patch_config_3mf_colors,
@@ -666,3 +668,68 @@ class TestCloudPrintImpl:
         # Config 3mf should be cleaned up
         config_path = tmp_path / "test.gcode_config.3mf"
         assert not config_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# _check_daemon_version
+# ---------------------------------------------------------------------------
+
+
+class TestCheckDaemonVersion:
+    def _mock_health(self, data: dict):
+        """Return a context manager that mocks urlopen to return *data* as JSON."""
+        import urllib.request
+
+        body = json.dumps(data).encode()
+
+        class FakeResp:
+            status = 200
+
+            def read(self):
+                return body
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        return patch.object(urllib.request, "urlopen", return_value=FakeResp())
+
+    def test_compatible_version_passes(self):
+        health = {
+            "status": "ok",
+            "bridge_version": "0.4.0",
+            "api_version": EXPECTED_API_VERSION,
+            "plugin_version": "02.05.00.00",
+        }
+        with self._mock_health(health):
+            _check_daemon_version()
+
+    def test_incompatible_version_raises(self):
+        health = {
+            "status": "ok",
+            "bridge_version": "0.9.0",
+            "api_version": 999,
+            "plugin_version": "02.05.00.00",
+        }
+        with self._mock_health(health):
+            with pytest.raises(RuntimeError, match="Bridge API version mismatch"):
+                _check_daemon_version()
+
+    def test_missing_api_version_warns(self, caplog):
+        health = {"status": "ok"}
+        with self._mock_health(health):
+            import logging
+
+            with caplog.at_level(logging.WARNING, logger="bambox.bridge"):
+                _check_daemon_version()
+            assert "does not report api_version" in caplog.text
+
+    def test_unreachable_daemon_warns(self, caplog):
+        with patch("urllib.request.urlopen", side_effect=OSError("refused")):
+            import logging
+
+            with caplog.at_level(logging.WARNING, logger="bambox.bridge"):
+                _check_daemon_version()
+            assert "Could not query bridge version" in caplog.text


### PR DESCRIPTION
## Summary

Closes #155.

- **Rust bridge**: `/health` endpoint now includes `bridge_version`, `api_version` (v1), and `plugin_version` fields
- **Python client**: `_check_daemon_version()` validates API compatibility on every daemon connect — raises `RuntimeError` on mismatch, warns gracefully for old bridges or unreachable daemons
- 4 new Python tests covering compatible, incompatible, missing version, and unreachable daemon cases

## Test plan

- [x] `ruff check` — zero errors
- [x] `ruff format --check` — clean
- [x] `mypy src/bambox` — zero errors
- [x] `pytest tests/test_bridge.py` — 39/39 pass
- [ ] Rust `cargo test` — needs CI (FFI shim not available in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)