### PR TITLE
fix: set send_message signing flag to fix cloud print -26

### DIFF
--- a/bridge/shim/shim.cpp
+++ b/bridge/shim/shim.cpp
@@ -294,8 +294,10 @@ int bambu_shim_start_subscribe(void* agent, const char* module) {
 
 int bambu_shim_send_message(void* agent, const char* dev_id, const char* json, int qos) {
     if (!fp_send_msg) return -1;
-    // flag=0 (no signing/encryption) — matches BambuStudio's default
-    return fp_send_msg(agent, std::string(dev_id), std::string(json), qos, 0);
+    // flag=1: enable request signing — the .so requires this for cloud operations
+    // that interact with the print pipeline. flag=0 silently disables signing,
+    // causing start_print to fail with -26 (BAMBU_NETWORK_SIGNED_ERROR).
+    return fp_send_msg(agent, std::string(dev_id), std::string(json), qos, 1);
 }
 
 int bambu_shim_send_message_to_printer(

--- a/changes/+fix-send-message-signing-flag.bugfix
+++ b/changes/+fix-send-message-signing-flag.bugfix
@@ -1,0 +1,1 @@
+Fix cloud printing -26 error: set send_message signing flag to 1 (was incorrectly set to 0, disabling request signing).


### PR DESCRIPTION
## Summary

Fixes cloud printing regression where `start_print` returns `-26` (BAMBU_NETWORK_SIGNED_ERROR).

- The 5th parameter to `bambu_network_send_message` controls request signing
- `c135be4` added this parameter with `flag=0`, which explicitly disabled signing
- Before that commit, the parameter was omitted (4-arg call), so the register contained nonzero garbage from the caller — signing was implicitly enabled
- Setting `flag=1` restores signing and should fix the `-26` error

## Test plan

- [ ] Install bridge from this PR's CI build
- [ ] `pkill bambox-bridge` (kill stale daemon)
- [ ] `bambox print <3mf> ` — verify print succeeds (no -26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)