### PR TITLE
fix: use Docker-only bridge on macOS to fix cloud print -26

### DIFF
--- a/changes/+macos-docker-only.bugfix
+++ b/changes/+macos-docker-only.bugfix
@@ -1,0 +1,1 @@
+Fix cloud printing on macOS: use Docker-only mode (the macOS .dylib signing gate blocks start_print from unsigned hosts with -26).

--- a/src/bambox/bridge.py
+++ b/src/bambox/bridge.py
@@ -12,6 +12,7 @@ import io
 import json
 import logging
 import os
+import platform
 import shutil
 import subprocess
 import tempfile
@@ -33,6 +34,7 @@ def _xml_ns(root: ET.Element) -> str:
 
 DOCKER_IMAGE = "estampo/bambox-bridge:bambu-02.05.00.00"
 EXPECTED_API_VERSION = 1
+_IS_MACOS = platform.system() == "Darwin"
 
 # ---------------------------------------------------------------------------
 # Credentials
@@ -83,11 +85,18 @@ def _write_token_json(cloud: dict[str, str], directory: Path | None = None) -> P
 
 
 def _find_local_bridge() -> str | None:
-    """Return path to a local ``bambox-bridge`` binary, or *None*."""
+    """Return path to a local ``bambox-bridge`` binary, or *None*.
+
+    Always returns *None* on macOS — the macOS ``libbambu_networking.dylib``
+    enforces a code-signing gate that rejects unsigned host binaries for
+    print-class operations (``start_print`` returns -26).  Docker routes
+    through Linux where the ``.so`` has no such restriction.
+    """
+    if _IS_MACOS:
+        return None
     found = shutil.which("bambox-bridge")
     if found:
         return found
-    # Check common install locations
     candidates = [
         Path.home() / ".local" / "bin" / "bambox-bridge",
         Path("/usr/local/bin/bambox-bridge"),
@@ -485,7 +494,8 @@ def _check_daemon_version() -> None:
     if api_version is None:
         log.warning(
             "Bridge daemon does not report api_version — "
-            "update with: pip install -U bambox  or  docker pull %s",
+            "restart it (pkill bambox-bridge) or update with: "
+            "pip install -U bambox  or  docker pull %s",
             DOCKER_IMAGE,
         )
         return
@@ -528,10 +538,16 @@ def _start_daemon(token_file: Path, *, verbose: bool = False) -> bool:
 
 
 def _ensure_daemon(token_file: Path, *, verbose: bool = False) -> bool:
-    """Ensure a daemon is running.  Returns True if available."""
+    """Ensure a daemon is running.  Returns True if available.
+
+    On macOS, checks for an existing daemon (e.g. running via Docker)
+    but will not auto-start a local binary (blocked by signed-app gate).
+    """
     if _daemon_ping():
         _check_daemon_version()
         return True
+    if _IS_MACOS:
+        return False
     log.info("No daemon running, starting one...")
     if _start_daemon(token_file, verbose=verbose):
         _check_daemon_version()

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -31,12 +31,16 @@ from bambox.bridge import (
 class TestFindLocalBridge:
     def test_finds_binary_on_path(self, tmp_path):
         """shutil.which hit should be returned."""
-        with patch("bambox.bridge.shutil.which", return_value="/usr/local/bin/bambox-bridge"):
+        with (
+            patch("bambox.bridge._IS_MACOS", False),
+            patch("bambox.bridge.shutil.which", return_value="/usr/local/bin/bambox-bridge"),
+        ):
             assert _find_local_bridge() == "/usr/local/bin/bambox-bridge"
 
     def test_finds_binary_in_local_bin(self, tmp_path):
         """Falls back to ~/.local/bin when not on PATH."""
         with (
+            patch("bambox.bridge._IS_MACOS", False),
             patch("bambox.bridge.shutil.which", return_value=None),
             patch("bambox.bridge.Path.home", return_value=tmp_path),
         ):
@@ -53,8 +57,17 @@ class TestFindLocalBridge:
         empty = tmp_path / "empty_home"
         empty.mkdir()
         with (
+            patch("bambox.bridge._IS_MACOS", False),
             patch("bambox.bridge.shutil.which", return_value=None),
             patch("bambox.bridge.Path.home", return_value=empty),
+        ):
+            assert _find_local_bridge() is None
+
+    def test_returns_none_on_macos(self):
+        """macOS always returns None (signed-app gate blocks local binary)."""
+        with (
+            patch("bambox.bridge._IS_MACOS", True),
+            patch("bambox.bridge.shutil.which", return_value="/usr/local/bin/bambox-bridge"),
         ):
             assert _find_local_bridge() is None
 


### PR DESCRIPTION
## Summary

Fixes cloud printing on macOS. The macOS `libbambu_networking.dylib` enforces a code-signing gate that rejects `start_print` from unsigned host binaries with `-26`. The Linux `.so` in Docker has no such restriction.

- `_find_local_bridge()` returns `None` on macOS — forces Docker fallback for all subprocess bridge calls
- `_ensure_daemon()` won't auto-start a local daemon on macOS, but will still use an existing one (e.g. a daemon running via Docker on port 8765)
- Confirmed: Docker bridge prints successfully, local macOS binary returns `-26`

## Test plan

- [x] `ruff check` — zero errors
- [x] `ruff format --check` — clean
- [x] `mypy src/bambox` — zero errors
- [x] `pytest tests/test_bridge.py` — 40/40 pass (including new macOS test)
- [ ] On macOS: `bambox print <3mf>` routes through Docker and prints successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)