### PR TITLE
feat: Docker daemon support for macOS

### DIFF
--- a/changes/+docker-daemon.feature
+++ b/changes/+docker-daemon.feature
@@ -1,0 +1,1 @@
+Support starting the bridge daemon via Docker on macOS (and when no local binary is available).

--- a/src/bambox/bridge.py
+++ b/src/bambox/bridge.py
@@ -548,8 +548,8 @@ def _start_daemon_docker(token_file: Path, *, verbose: bool = False) -> bool:
     """Start the bridge daemon as a Docker container."""
     try:
         docker_info = subprocess.run(["docker", "info"], capture_output=True, timeout=10)
-    except FileNotFoundError:
-        log.warning("Docker not installed — cannot start daemon")
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        log.warning("Docker not available — cannot start daemon")
         return False
     if docker_info.returncode != 0:
         log.warning("Docker not running — cannot start daemon")
@@ -591,11 +591,14 @@ def _start_daemon_docker(token_file: Path, *, verbose: bool = False) -> bool:
 
 def _stop_daemon_docker() -> None:
     """Stop the Docker daemon container if running."""
-    subprocess.run(
-        ["docker", "rm", "-f", DOCKER_DAEMON_CONTAINER],
-        capture_output=True,
-        timeout=10,
-    )
+    try:
+        subprocess.run(
+            ["docker", "rm", "-f", DOCKER_DAEMON_CONTAINER],
+            capture_output=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
 
 
 def _ensure_daemon(token_file: Path, *, verbose: bool = False) -> bool:

--- a/src/bambox/bridge.py
+++ b/src/bambox/bridge.py
@@ -509,24 +509,28 @@ def _check_daemon_version() -> None:
 
 
 def _start_daemon(token_file: Path, *, verbose: bool = False) -> bool:
-    """Start the bridge daemon in the background.  Returns True if started."""
+    """Start the bridge daemon in the background.  Returns True if started.
+
+    Tries local binary first, falls back to Docker on macOS or when no
+    local binary is available.
+    """
     binary = _find_local_bridge()
-    if not binary:
-        return False
+    if binary:
+        cmd = [binary]
+        if verbose:
+            cmd.append("-v")
+        cmd.extend(["-c", str(token_file.resolve()), "daemon", "--port", "8765"])
+        log.debug("Starting daemon: %s", " ".join(cmd))
+        subprocess.Popen(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    else:
+        if not _start_daemon_docker(token_file, verbose=verbose):
+            return False
 
-    cmd = [binary]
-    if verbose:
-        cmd.append("-v")
-    cmd.extend(["-c", str(token_file.resolve()), "daemon", "--port", "8765"])
-    log.debug("Starting daemon: %s", " ".join(cmd))
-    subprocess.Popen(
-        cmd,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        start_new_session=True,
-    )
-
-    # Wait for it to become responsive
     import time
 
     for _ in range(30):
@@ -537,17 +541,71 @@ def _start_daemon(token_file: Path, *, verbose: bool = False) -> bool:
     return False
 
 
+DOCKER_DAEMON_CONTAINER = "bambox-bridge-daemon"
+
+
+def _start_daemon_docker(token_file: Path, *, verbose: bool = False) -> bool:
+    """Start the bridge daemon as a Docker container."""
+    try:
+        docker_info = subprocess.run(["docker", "info"], capture_output=True, timeout=10)
+    except FileNotFoundError:
+        log.warning("Docker not installed — cannot start daemon")
+        return False
+    if docker_info.returncode != 0:
+        log.warning("Docker not running — cannot start daemon")
+        return False
+
+    subprocess.run(
+        ["docker", "rm", "-f", DOCKER_DAEMON_CONTAINER],
+        capture_output=True,
+        timeout=10,
+    )
+
+    token_real = str(token_file.resolve())
+    cmd = [
+        "docker",
+        "run",
+        "-d",
+        "--name",
+        DOCKER_DAEMON_CONTAINER,
+        "--platform",
+        "linux/amd64",
+        "-p",
+        "8765:8765",
+        "-v",
+        f"{token_real}:/tmp/credentials.json:ro",
+        DOCKER_IMAGE,
+        "-c",
+        "/tmp/credentials.json",
+    ]
+    if verbose:
+        cmd.append("-v")
+    cmd.extend(["daemon", "--port", "8765", "--bind", "0.0.0.0"])
+    log.debug("Starting daemon (docker): %s", " ".join(cmd))
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    if result.returncode != 0:
+        log.warning("Docker daemon start failed: %s", result.stderr.strip())
+        return False
+    return True
+
+
+def _stop_daemon_docker() -> None:
+    """Stop the Docker daemon container if running."""
+    subprocess.run(
+        ["docker", "rm", "-f", DOCKER_DAEMON_CONTAINER],
+        capture_output=True,
+        timeout=10,
+    )
+
+
 def _ensure_daemon(token_file: Path, *, verbose: bool = False) -> bool:
     """Ensure a daemon is running.  Returns True if available.
 
-    On macOS, checks for an existing daemon (e.g. running via Docker)
-    but will not auto-start a local binary (blocked by signed-app gate).
+    On macOS, starts the daemon via Docker. On Linux, uses the local binary.
     """
     if _daemon_ping():
         _check_daemon_version()
         return True
-    if _IS_MACOS:
-        return False
     log.info("No daemon running, starting one...")
     if _start_daemon(token_file, verbose=verbose):
         _check_daemon_version()

--- a/src/bambox/cli.py
+++ b/src/bambox/cli.py
@@ -1128,13 +1128,14 @@ def stop() -> None:
     """Stop the bridge daemon."""
     import urllib.request
 
-    from bambox.bridge import DAEMON_URL
+    from bambox.bridge import DAEMON_URL, _stop_daemon_docker
 
     try:
         req = urllib.request.Request(f"{DAEMON_URL}/shutdown", method="POST")
         urllib.request.urlopen(req, timeout=5)
     except (OSError, Exception):
         pass
+    _stop_daemon_docker()
     ui.success("Daemon stopped")
 
 
@@ -1151,6 +1152,8 @@ def start(
     import subprocess as sp
 
     from bambox.bridge import (
+        DOCKER_DAEMON_CONTAINER,
+        DOCKER_IMAGE,
         _daemon_ping,
         _find_local_bridge,
         _start_daemon,
@@ -1167,19 +1170,44 @@ def start(
 
     if foreground:
         binary = _find_local_bridge()
-        if not binary:
-            ui.error("bambox-bridge binary not found")
-            sys.exit(1)
-        cmd = [binary]
-        if _verbose:
-            cmd.append("-v")
-        cmd.extend(["-c", str(token_file.resolve()), "daemon", "--port", "8765"])
-        ui.info("Starting daemon in foreground (Ctrl-C to stop)")
-        try:
-            result = sp.run(cmd)
-            sys.exit(result.returncode)
-        except KeyboardInterrupt:
-            ui.console.print()
+        if binary:
+            cmd = [binary]
+            if _verbose:
+                cmd.append("-v")
+            cmd.extend(["-c", str(token_file.resolve()), "daemon", "--port", "8765"])
+            ui.info("Starting daemon in foreground (Ctrl-C to stop)")
+            try:
+                result = sp.run(cmd)
+                sys.exit(result.returncode)
+            except KeyboardInterrupt:
+                ui.console.print()
+        else:
+            token_real = str(token_file.resolve())
+            cmd = [
+                "docker",
+                "run",
+                "--rm",
+                "--name",
+                DOCKER_DAEMON_CONTAINER,
+                "--platform",
+                "linux/amd64",
+                "-p",
+                "8765:8765",
+                "-v",
+                f"{token_real}:/tmp/credentials.json:ro",
+                DOCKER_IMAGE,
+                "-c",
+                "/tmp/credentials.json",
+            ]
+            if _verbose:
+                cmd.append("-v")
+            cmd.extend(["daemon", "--port", "8765", "--bind", "0.0.0.0"])
+            ui.info("Starting daemon in foreground via Docker (Ctrl-C to stop)")
+            try:
+                result = sp.run(cmd)
+                sys.exit(result.returncode)
+            except KeyboardInterrupt:
+                ui.console.print()
     elif _start_daemon(token_file, verbose=_verbose):
         ui.success("Daemon started")
     else:
@@ -1196,7 +1224,13 @@ def restart(
     """Restart the bridge daemon."""
     import urllib.request
 
-    from bambox.bridge import DAEMON_URL, _start_daemon, _write_token_json, load_credentials
+    from bambox.bridge import (
+        DAEMON_URL,
+        _start_daemon,
+        _stop_daemon_docker,
+        _write_token_json,
+        load_credentials,
+    )
 
     # Stop if running
     try:
@@ -1204,6 +1238,7 @@ def restart(
         urllib.request.urlopen(req, timeout=5)
     except (OSError, Exception):
         pass
+    _stop_daemon_docker()
     time.sleep(1)
 
     creds = load_credentials(credentials)

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -761,6 +761,15 @@ class TestStartDaemonDocker:
         with patch("bambox.bridge.subprocess.run", side_effect=FileNotFoundError):
             assert _start_daemon_docker(token) is False
 
+    def test_returns_false_when_docker_info_times_out(self, tmp_path):
+        token = tmp_path / "creds.json"
+        token.write_text("{}")
+        with patch(
+            "bambox.bridge.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(["docker", "info"], 10),
+        ):
+            assert _start_daemon_docker(token) is False
+
     def test_returns_false_when_docker_not_running(self, tmp_path):
         token = tmp_path / "creds.json"
         token.write_text("{}")

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -13,6 +13,8 @@ from unittest.mock import patch
 import pytest
 
 from bambox.bridge import (
+    DOCKER_DAEMON_CONTAINER,
+    DOCKER_IMAGE,
     EXPECTED_API_VERSION,
     _build_ams_mapping,
     _check_daemon_version,
@@ -20,6 +22,8 @@ from bambox.bridge import (
     _find_local_bridge,
     _patch_config_3mf_colors,
     _run_bridge_local,
+    _start_daemon_docker,
+    _stop_daemon_docker,
     _strip_gcode_from_3mf,
     _write_token_json,
     load_credentials,
@@ -746,3 +750,64 @@ class TestCheckDaemonVersion:
             with caplog.at_level(logging.WARNING, logger="bambox.bridge"):
                 _check_daemon_version()
             assert "Could not query bridge version" in caplog.text
+
+
+class TestStartDaemonDocker:
+    """Tests for _start_daemon_docker."""
+
+    def test_returns_false_when_docker_not_installed(self, tmp_path):
+        token = tmp_path / "creds.json"
+        token.write_text("{}")
+        with patch("bambox.bridge.subprocess.run", side_effect=FileNotFoundError):
+            assert _start_daemon_docker(token) is False
+
+    def test_returns_false_when_docker_not_running(self, tmp_path):
+        token = tmp_path / "creds.json"
+        token.write_text("{}")
+        failed = subprocess.CompletedProcess([], returncode=1, stderr="error")
+        with patch("bambox.bridge.subprocess.run", return_value=failed):
+            assert _start_daemon_docker(token) is False
+
+    def test_launches_container_on_success(self, tmp_path):
+        token = tmp_path / "creds.json"
+        token.write_text("{}")
+        ok = subprocess.CompletedProcess([], returncode=0, stdout="", stderr="")
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(list(cmd))
+            return ok
+
+        with patch("bambox.bridge.subprocess.run", side_effect=fake_run):
+            assert _start_daemon_docker(token) is True
+        docker_run_cmd = calls[2]
+        assert "docker" in docker_run_cmd[0]
+        assert "-d" in docker_run_cmd
+        assert DOCKER_DAEMON_CONTAINER in docker_run_cmd
+        assert DOCKER_IMAGE in docker_run_cmd
+
+    def test_returns_false_on_docker_run_failure(self, tmp_path):
+        token = tmp_path / "creds.json"
+        token.write_text("{}")
+        ok = subprocess.CompletedProcess([], returncode=0, stdout="", stderr="")
+        fail = subprocess.CompletedProcess([], returncode=1, stdout="", stderr="fail")
+        results = iter([ok, ok, fail])
+
+        with patch("bambox.bridge.subprocess.run", side_effect=lambda *a, **kw: next(results)):
+            assert _start_daemon_docker(token) is False
+
+
+class TestStopDaemonDocker:
+    """Tests for _stop_daemon_docker."""
+
+    def test_calls_docker_rm(self):
+        calls: list[list[str]] = []
+        ok = subprocess.CompletedProcess([], returncode=0)
+
+        def fake_run(cmd, **kwargs):
+            calls.append(list(cmd))
+            return ok
+
+        with patch("bambox.bridge.subprocess.run", side_effect=fake_run):
+            _stop_daemon_docker()
+        assert calls[0] == ["docker", "rm", "-f", DOCKER_DAEMON_CONTAINER]


### PR DESCRIPTION
## Summary
- On macOS (or when no local bridge binary is found), `bambox daemon start` now auto-launches the daemon via Docker container
- `bambox daemon start --foreground` works with Docker too (runs interactively, Ctrl-C to stop)
- `bambox daemon stop` and `restart` clean up the Docker container alongside the HTTP shutdown
- `_start_daemon()` in bridge.py falls back to `_start_daemon_docker()` when `_find_local_bridge()` returns None

## Test plan
- [x] 45 bridge tests pass (including 5 new Docker daemon tests)
- [x] ruff check, ruff format, mypy all pass
- [ ] CI matrix (linux/macOS/windows × py3.11-3.13)
- [ ] Manual: `bambox daemon start` on macOS starts Docker container
- [ ] Manual: `bambox daemon stop` removes the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)