### PR TITLE
fix(ci): detect squash-merged release PRs via PR-number lookup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,16 +31,38 @@ jobs:
           MSG=$(git log -1 --format=%s "$SHA")
           echo "Commit message: $MSG"
 
-          # Primary: parse branch name from merge commit message (instant, no API race)
+          # Primary: parse branch name from merge commit message.
+          # Works for true merge commits ("Merge pull request #N from owner/release/vX.Y.Z")
+          # but NOT for squash merges, whose message is just the PR title + "(#N)".
           VERSION=$(echo "$MSG" \
             | grep -oP 'release/v\K\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?' \
             | head -1 || true)
 
-          # Fallback: query the commits/pulls API
+          # Fallback 1: extract PR number from the merge message and query the PR
+          # directly. This is the path that handles squash merges, and it survives
+          # auto-delete-head-branches — unlike the commits/{sha}/pulls endpoint,
+          # which returns nothing once the head ref is gone (this is what silently
+          # broke v0.4.1; see issue #195).
           if [[ -z "$VERSION" ]]; then
-            echo "Merge message did not match — falling back to API..."
+            echo "Merge message did not contain branch name — looking for PR number..."
+            PR_NUMBER=$(echo "$MSG" | grep -oP '#\K\d+' | head -1 || true)
+            if [[ -n "$PR_NUMBER" ]]; then
+              echo "Found PR #${PR_NUMBER} — querying head ref..."
+              HEAD_REF=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" \
+                --jq '.head.ref' 2>/dev/null || true)
+              echo "PR #${PR_NUMBER} head ref: ${HEAD_REF:-<none>}"
+              VERSION=$(echo "$HEAD_REF" \
+                | grep -oP '^release/v\K\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?$' \
+                | head -1 || true)
+            fi
+          fi
+
+          # Fallback 2: query the commits/pulls API. Kept as a last resort for
+          # non-PR pushes (e.g. direct merges) where a head ref still exists.
+          if [[ -z "$VERSION" ]]; then
+            echo "PR lookup did not match — falling back to commits/pulls API..."
             BRANCHES=$(gh api "repos/${{ github.repository }}/commits/${SHA}/pulls" \
-              --jq '.[].head.ref')
+              --jq '.[].head.ref' 2>/dev/null || true)
             echo "Associated PR branches: ${BRANCHES:-<none>}"
             VERSION=$(echo "$BRANCHES" \
               | grep -oP '^release/v\K\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?$' \

--- a/changes/+release-detection-pr-lookup.bugfix
+++ b/changes/+release-detection-pr-lookup.bugfix
@@ -1,0 +1,1 @@
+Release workflow now detects squash-merged release PRs by querying the PR by number, surviving auto-deleted head branches.


### PR DESCRIPTION
Fixes #195. Does **not** close it on its own — verification requires an actual release cycle.

## What went wrong

The \`detect-release\` job in \`.github/workflows/release.yml\` silently no-op'd v0.4.1 (PR #189, merged \`cfe90df\`). Workflow ran, went green in 9 seconds, no tag, no GH release, no PyPI publish, no bridge binary build. Both detection paths failed:

1. **Branch-name regex** (\`grep -oP 'release/v\\K...\` on the merge commit message) assumes the message contains the source branch name. That's only true for true merge commits. Squash merges use \`<PR title> (#N)\`, and #189's message was just \`Release v0.4.1 (#189)\` — the branch name \`release/v0.4.1\` never appears.
2. **\`commits/{sha}/pulls\` API fallback** returns an empty list once the head branch has been auto-deleted. Auto-delete-head-branches is on, and by the time the workflow ran, \`release/v0.4.1\` was gone. Run log: \`Associated PR branches: <none>\`.

Both paths came up empty → \`is_release=false\` → every downstream job short-circuited → workflow exited green.

## The fix

Adds a middle fallback between the two existing paths:

\`\`\`
branch-name regex (fast path, true merge commits)
        ↓ miss
PR-number lookup  ← NEW
        ↓ miss
commits/{sha}/pulls API (last resort)
\`\`\`

The PR-number lookup:
1. Extracts the first \`#NNN\` from the merge message (\`grep -oP '#\\K\\d+' | head -1\`).
2. Calls \`gh api repos/.../pulls/{number}\` and reads \`.head.ref\`.
3. Matches the result against \`release/vX.Y.Z\`.

Unlike \`commits/{sha}/pulls\`, the pulls-by-id endpoint persists \`head.ref\` after the branch is deleted — verified by querying #189 while writing this fix: \`headRefName: \"release/v0.4.1\"\` came back cleanly.

## Regex verification

Tested the PR-number extraction against the merge-commit formats we care about:

| Commit message | Extracted PR |
|---|---|
| \`Release v0.4.1 (#189)\` | 189 |
| \`Merge pull request #200 from estampo/release/v0.5.0\` | 200 |
| \`Release v1.2.3rc1 (#42)\` | 42 |
| \`docs: tweak readme (#7)\` | 7 |

False positives are blocked by the subsequent \`release/vX.Y.Z\` match on the head ref — a non-release PR like the last row will extract a PR number but then fail the branch-ref regex and leave \`VERSION\` empty.

## What's NOT in this PR

- **v0.4.1 recovery.** This PR only fixes detection. v0.4.1 still needs to be shipped via **Actions → Release → Run workflow** with \`tag: v0.4.1\`, or rolled forward as v0.4.2 once this merges. Discussed with maintainer — leaning toward rolling forward, so v0.4.1 stays a phantom.
- **Test coverage for the workflow.** No workflow-level test harness exists today, and adding one is out of scope. The real test is cutting the next release and seeing it publish.
- **Unrelated \`uv.lock\` drift.** Running the pre-PR checks noticed \`uv.lock\` has \`bambox version = \"0.3.0\"\` while \`pyproject.toml\` says \`0.4.1\`. Restored to main's state in this PR to keep it surgical; worth a separate one-line fix.

## Pre-PR checks

- \`uv run ruff check src tests\` — All checks passed
- \`uv run ruff format --check src tests\` — 36 files already formatted
- \`uv run mypy src/bambox\` — no issues in 17 source files
- \`uv run pytest\` — 588 passed, 40 skipped

## Verification plan

Cannot be verified in CI on this PR — this workflow only runs on pushes to main. Verification is the next release cycle: fix the stale \`uv.lock\`, cut 0.4.2 via Prepare Release, merge, confirm tag + GH release + PyPI publish + bridge binary build all appear without manual intervention. **Do not close #195 until that cycle completes successfully.**