### PR TITLE
chore: sync uv.lock with pyproject.toml (0.3.0 -> 0.4.1)

### DIFF
--- a/changes/+uv-lock-sync.misc
+++ b/changes/+uv-lock-sync.misc
@@ -1,0 +1,1 @@
+Sync uv.lock with pyproject.toml — the lockfile had bambox at 0.3.0 while the project was at 0.4.1.

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "bambox"
-version = "0.3.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
One-line fix for stale \`uv.lock\`.

## Problem

\`uv.lock\` had \`bambox version = \"0.3.0\"\` while \`pyproject.toml\` has been at \`0.4.1\` since \`cfe90df\`. Any fresh \`uv sync\` reconciles it locally, but nobody had committed the result, so the drift kept coming back.

Noticed while running the four pre-PR checks for #198.

## Change

\`\`\`diff
 [[package]]
 name = \"bambox\"
-version = \"0.3.0\"
+version = \"0.4.1\"
\`\`\`

Produced by running \`uv lock\` on a clean checkout of main. No dependency changes — just the local-package version field catching up.

## Pre-PR checks

- \`uv run ruff check src tests\` — passed (from the #198 run; no code changed here)
- \`uv run ruff format --check src tests\` — passed
- \`uv run mypy src/bambox\` — passed
- \`uv run pytest\` — 588 passed, 40 skipped