### PR TITLE
docs: soft-launch truthfulness pass on ROADMAP and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,38 @@
 
 Package plain G-code into Bambu Lab `.gcode.3mf` files — no OrcaSlicer required.
 
+## Known limitations
+
+Read these before pointing bambox at a real printer. None of them are going
+away in the very near term.
+
+- **Only the Bambu P1S with AMS is tested.** The architecture is general and
+  other Bambu models (X1C, A1, A1 Mini) can be added by dropping in machine
+  profiles, but we don't have the hardware in the loop to validate them.
+  If you have one of those printers and want to help test, please
+  [open an issue](https://github.com/estampo/bambox/issues/new) — see also
+  the [roadmap](ROADMAP.md#future).
+- **`bambox cancel` (CLI) is disabled.** `libbambu_networking` rejects
+  print-class MQTT commands (stop, pause, resume, skip_objects) when the
+  hosting process is not an officially signed BambuStudio binary. The CLI
+  returns a structured error pointing at
+  [`docs/signed-app-gate.md`](docs/signed-app-gate.md), which has the full
+  investigation. The daemon `/cancel` endpoint is unaffected because it
+  also handles in-flight upload cancellation, which still works.
+- **macOS always uses the Docker bridge.** The native `bambox-bridge`
+  binary hits the same code-signing gate on macOS and cannot send
+  `start_print` — bambox detects macOS and forces the Docker path, so
+  Docker Desktop (or a compatible runtime) must be installed and running
+  for `print`, `status`, `login`, and `daemon`.
+- **No LAN mode.** Cloud connectivity to Bambu's servers is required for
+  every bridged operation. LAN-direct support is tracked in
+  [#91](https://github.com/estampo/bambox/issues/91).
+- **No Windows native bridge.** Windows users need Docker Desktop for any
+  bridged command; Linux ARM64 users need Docker + QEMU.
+- **PyPI publish is manual for v0.4.1.** The release workflow silently
+  no-op'd on the v0.4.1 merge (now [fixed](https://github.com/estampo/bambox/pull/198)).
+  If `pip install bambox` gives you 0.4.0, that's why.
+
 `bambox` is a standalone Python library and CLI for creating printer-ready
 Bambu Lab archives from any G-code source. It handles the BBL-specific
 packaging format (metadata, checksums, settings) so that any slicer —
@@ -75,19 +107,22 @@ This is all you need for `pack`, `repack`, and `validate`. For `print`,
 The `print`, `status`, and `login` commands communicate with Bambu printers
 via a cloud bridge. You have two options:
 
-**Option A — Native binary (recommended, Linux x86_64 and macOS):**
+**Option A — Native binary (Linux x86_64 only):**
 
 ```bash
 curl -fsSL https://github.com/estampo/bambox/releases/latest/download/install.sh | sh
 ```
 
-This installs `bambox-bridge` to `~/.local/bin`.
+This installs `bambox-bridge` to `~/.local/bin`. macOS, Windows, and Linux
+ARM64 users should use Option B.
 
-**Option B — Docker (all platforms):**
+**Option B — Docker (all other platforms):**
 
 If you have Docker installed and running, bambox uses the
 `estampo/bambox-bridge` image automatically — no extra setup needed.
-This is the only option on Windows and Linux ARM64.
+This is the **only** supported option on macOS, Windows, and Linux ARM64.
+See [Known limitations](#known-limitations) for why macOS cannot use the
+native binary.
 
 ### Platform Support
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,6 @@ away in the very near term.
   [#91](https://github.com/estampo/bambox/issues/91).
 - **No Windows native bridge.** Windows users need Docker Desktop for any
   bridged command; Linux ARM64 users need Docker + QEMU.
-- **PyPI publish is manual for v0.4.1.** The release workflow silently
-  no-op'd on the v0.4.1 merge (now [fixed](https://github.com/estampo/bambox/pull/198)).
-  If `pip install bambox` gives you 0.4.0, that's why.
 
 `bambox` is a standalone Python library and CLI for creating printer-ready
 Bambu Lab archives from any G-code source. It handles the BBL-specific

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # bambox Roadmap
 
-This is a living document updated at each release. It captures what's done, what's in scope for the next milestone, and what's explicitly deferred.
+This is a living document updated at each release. It captures what has shipped, what is in scope for the next milestone, and what is deliberately deferred.
 
 ## Vision
 
@@ -9,7 +9,7 @@ bambox is the **BBL compatibility layer** — the last mile between a slicer and
 1. **Packs** properly formed G-code into `.gcode.3mf` archives that BBL firmware accepts
 2. **Fixes up** G-code and 3MF metadata so prints work correctly on BBL printers
 3. **Validates** that the result is firmware-compliant before writing
-4. **Communicates** with BBL printers for status, AMS queries, and print control (LAN + cloud)
+4. **Communicates** with BBL printers for status, AMS queries, and print control (via cloud; LAN mode is deferred)
 5. **Manages** printer credentials
 
 bambox handles two layers of BBL-specific fixup:
@@ -20,121 +20,118 @@ bambox handles two layers of BBL-specific fixup:
 
 bambox is **not** a slicer, not a pipeline orchestrator (that's estampo), and not a general-purpose G-code transformer. It specifically owns "make this printable on a BBL printer."
 
----
+## Tested hardware
 
-## v0.1.x — Done
-
-Core packaging library with Bambu Connect compatibility.
-
-- Core `.gcode.3mf` archive construction with MD5 checksums
-- Template-driven 544-key `project_settings.config` generation
-- Machine base profiles (P1S) with filament overlays (PLA, ASA, PETG-CF)
-- Automatic array padding and missing-key fixup for Bambu Connect firmware
-- Cloud printing via Docker bridge with bind-mount and baked fallback
-- AMS tray mapping and printer status querying
-- OrcaSlicer-to-Jinja2 template conversion and rendering
-- G-code component assembly (start + toolpath + end)
-- CuraEngine Docker slicer backend prototype
-- CLI with `pack`, `print`, and `status` commands
-- G-code-to-PNG thumbnail rendering
+Everything in bambox is developed and validated against a **Bambu P1S with AMS** — that's the only hardware the maintainers have in the loop. The architecture is general and additional printer models are on the roadmap below, but they're gated on external contributors with hardware access — see the "Future" section.
 
 ---
 
-## v0.2.0 — In Progress
+## Shipped
 
-**Theme: Wire up the pack pipeline and harden the Rust bridge.**
+### v0.4.1 — 2026-04-13
 
-### Pack pipeline
+**Theme: daemon HTTP API, Docker on macOS, signed-app gate investigation.**
 
-Wire up the full `bambox pack` flow: G-code in → BBL-compatible `.gcode.3mf` out.
+- `bambox daemon` subcommands (`start`, `stop`, `restart`, `status`); `--foreground` flag
+- CLI routes `print` / `cancel` through daemon HTTP when running, with subprocess fallback
+- Bridge version check on daemon connect (`/health` reports bridge, API, and plugin versions)
+- macOS bridge daemon can start via Docker when no local binary is available
+- Credential env var aligned: Rust bridge uses `BAMBOX_CREDENTIALS`; Python checks macOS `~/Library/Application Support/` paths
+- Cloud print fix for `BAMBU_NETWORK_SIGNED_ERROR (-26)`: X-BBL headers updated to BambuStudio 02.05.00.66, stable UUID Device-ID, platform-aware OS-Type
+- macOS forced to Docker-only bridge — the `.dylib` signing gate blocks `start_print` from unsigned hosts
+- `libbambu_networking` signed-app gate documented (`docs/signed-app-gate.md`); CLI `cancel` subcommand disabled pending a viable workaround — the daemon `/cancel` endpoint is unchanged
+- Various daemon polish: pre-subscribe configured printers at startup, 1s status updates when idle
+- Bridge FFI hardening: `send_message` signature fix, symbol resolution diagnostics, MQTT cancel QoS/param fix
 
-- [ ] Wire templates.py and settings.py into the CLI `pack` command (#27)
-- [ ] Update CLAUDE.md module ownership and "What bambox is NOT" to reflect BBL compatibility layer role (#27)
-- [ ] Z-change layer detection fallback for unknown slicers (#30)
-- [ ] Evaluate whether assemble.py is still needed or if start/end injection replaces it (#27)
+### v0.4.0 — 2026-04-11
 
-### Rust bridge hardening (#28)
+**Theme: CLI parity with the legacy C++ bridge; daemon-backed `status -w`.**
 
-- [ ] Replace `CString::new().unwrap()` with error propagation (~20 call sites)
-- [ ] Move agent to dedicated thread with command channel (unblock HTTP during MQTT queries)
-- [ ] Wire up print cancellation (`WasCancelledFn` → `AtomicBool`)
-- [ ] Replace `static mut SAVED_STDOUT` with `AtomicI32`
+- Rust bridge `print` and `cancel` CLI subcommands — CLI parity with the legacy C++ bridge
+- `bambox status -w` auto-starts the Rust daemon and polls via HTTP; sub-second updates from MQTT push
+- Credentials file created atomic-0o600 via `os.open()` / `mkstemp` (no brief world-readable window)
+- Rust `bambox-bridge` documented as the replacement for the legacy C++ `estampo/cloud-bridge` (ADR-002)
+- Docker image shrunk from 174MB to 60MB (distroless, multi-stage fetch)
 
-### Infrastructure
+### v0.3.x — 2026-04-10/11
 
-- [ ] Dockerfile for building and running the Rust bridge (#29)
-- [ ] Towncrier fragment check in CI (#19)
+**Theme: CLI TUI parity with estampo; Typer + Rich migration.**
 
-### Done (Rust bridge prototype)
-- [x] C++ shim wrapping `libbambu_networking.so` functions via dlopen
-- [x] `build.rs` compiling shim as C++17 and linking `libdl`
-- [x] `BambuAgent` struct managing agent lifecycle with Drop cleanup
-- [x] Thread-safe callback state (atomics + Mutex)
-- [x] `status` subcommand: connect, query, print JSON, exit
-- [x] `watch` subcommand: stdin-driven MQTT message streaming
-- [x] `daemon` subcommand: axum HTTP server
-- [x] Credential loading from `~/.config/estampo/credentials.toml` and JSON
-- [x] HTTP endpoints: `/ping`, `/health`, `/status/{device}`, `/ams/{device}`, `/print`, `/cancel/{device}`, `/shutdown`
-- [x] 3MF upload via multipart POST (eliminates bind-mount issues)
-- [x] Cached printer state with 30s TTL
-- [x] Full print pipeline: AMS mapping, color patching, config 3MF stripping
-- [x] Retry logic for `-3140` enc flag failures (15s backoff, 5 retries)
-- [x] Unit tests for credential parsing, callbacks, 3MF processing, HTTP handlers
+- `bambox status` display parity with estampo TUI (rounded temperatures, color swatches, print stages, active tray)
+- CLI migrated from argparse to Typer + Rich; shell completion support
+- `bambox cancel` subcommand (later hobbled by the signed-app gate)
+- Bridge binary prefers `~/.config/bambox/` for credentials (legacy `~/.config/estampo/` still supported)
+- Release pipeline fix for pre-release tag false positives (e.g. `v0.3.0rc1` no longer blocks `v0.3.0`)
+- Install script included in GitHub release assets
 
-### Out of scope for v0.2.0
-- Multi-filament AMS tool-change rewriting
-- Migrating code from estampo
-- LAN printing mode
+### v0.2.x — 2026-04-09
 
----
+**Theme: wire up the pack pipeline; harden the Rust bridge; add `validate`.**
 
-## v0.3.0 — Planned
+- Full `bambox pack` CLI wired through `templates.py` + `settings.py` (544-key auto-generation)
+- `bambox repack` command for fixing up existing OrcaSlicer archives
+- `bambox login` for Bambu Cloud authentication and printer configuration
+- `bambox validate` command (11 error rules, 9 warning rules, JSON output, `--reference` comparison)
+- CuraEngine `T0`/`T1` rewrite to Bambu `M620`/`M621` for multi-filament prints
+- AMS slot assignment in `bambox pack -f` (`-f 3:PETG-CF`)
+- Z-change layer detection fallback for unknown slicers (layer progress on any G-code source)
+- Bridge runner: local `bambox-bridge` binary tried before Docker
+- Auto-detect printers when no device ID given; `/printers` daemon endpoint
+- Rust bridge hardening: agent command channel, `CString` panic removal, callback lifetime fixes
+- Multi-stage Dockerfile for the Rust bridge daemon
+- CI workflow for cross-compiled bridge binaries (Linux, macOS)
 
-**Theme: Printer communication. Absorb printer code from estampo.**
+### v0.1.0 — 2026-03-15
 
-Coordinates with estampo v0.4.0 — bambox becomes the standalone BBL library.
-
-- Migrate `cloud/bridge.py` from estampo (rewrite as HTTP client to Rust daemon)
-- Migrate `cloud/ams.py`, `auth.py`, `credentials.py`, `printer.py` from estampo
-- Migrate `thumbnails.py`, `bambu_connect_fixup()` from estampo
-- Migrate associated tests
-- `bambox credentials` CLI for managing cloud/LAN credentials
-- LAN printing mode (direct IP + access code, no cloud dependency)
-- WebSocket `/watch/{device}` endpoint for real-time status
-- Send print completion (100%) command to printer
-- estampo drops printer code, adds optional `bambox` dependency
+Initial release. Core `.gcode.3mf` archive packaging with Bambu Connect compatibility, 544-key `project_settings.config` generation, P1S base profile with filament overlays, Docker bridge cloud printing, CLI `pack` / `print` / `status`.
 
 ---
 
-## v0.4.0 — Planned
+## Current focus
 
-**Theme: Multi-filament support.**
+No fixed theme yet. Near-term work is driven by soft-launch readiness:
 
-- T-command → M620/M621 AMS tool-change rewriting for multi-material prints
-- `bambox validate` command — check G-code + config against firmware constraints before packing
-- Validation: tool count vs AMS slot count, required markers present, settings completeness
-- Support for additional Bambu printer models (X1C, A1, A1 Mini)
+- Truth-in-advertising pass on README and ROADMAP (this document)
+- End-to-end quickstart walkthrough with a checked-in sample G-code
+- Release workflow detection fix (v0.4.1 shipped in code but the release pipeline silently no-op'd; fixed in #198, verification pending the next release cycle)
 
----
-
-## v1.0 — Sketch
-
-**Theme: Stable public API.**
-
-- Public API freeze for `pack_gcode_3mf()`, `build_project_settings()`, `fixup_project_settings()`
-- Comprehensive API documentation
-- Release automation and Docker image publishing
+See the open issues for the live list.
 
 ---
 
-## Deferred / Backlog
+## Future
 
-- Moonraker (non-Bambu) printer support
-- Profile editing or merging UI
+Not scheduled. Picked up when the right constraint lifts — either external demand or contributor access to hardware we don't have.
+
+### Multi-printer support (contributor-gated)
+
+The architecture is general: machine profiles in `src/bambox/data/profiles/` drive everything, and adding an X1C / A1 / A1 Mini is mechanically a matter of dropping in a new base profile and validating against real hardware. The blocker is **validation** — we only have a P1S+AMS in the loop, so anything we shipped for other models would be guessing.
+
+If you have an X1C, A1, or A1 Mini and are willing to help test, open an issue or PR — we'll work through the profile with you. Until then, these stay in the future bucket rather than on a scheduled milestone.
+
+### LAN printing
+
+Direct IP + access code, no cloud dependency. Tracked as #91. Interesting both for privacy-minded users and as a possible workaround for the signed-app gate on print-class MQTT commands (LAN-mode paths may not go through the same signing check — unverified).
+
+### Multi-filament AMS tool-change rewriting for complex prints
+
+Basic `T0`/`T1` → `M620`/`M621` rewriting shipped in v0.2.0. More elaborate multi-material scenarios (purge tower tuning, flush-volume matrix integration, per-object filament overrides) are deferred until real multi-material users show up.
+
+### Public API freeze (v1.0)
+
+`pack_gcode_3mf()`, `build_project_settings()`, `fixup_project_settings()` are the natural candidates for a stable contract. Not worth freezing until the surrounding modules settle.
+
+### Moonraker / non-Bambu printer support
+
+Out of scope. bambox is the **BBL compatibility layer**. General-purpose printer support lives in estampo.
+
+### Profile editing / merging UI
+
+Out of scope. bambox loads and overlays profiles; it does not edit them.
 
 ---
 
-## Architecture North Star
+## Architecture north star
 
 Two projects, each owning one concern:
 

--- a/changes/+soft-launch-docs.misc
+++ b/changes/+soft-launch-docs.misc
@@ -1,0 +1,1 @@
+Rewrite ROADMAP.md to reflect shipped v0.2–v0.4.1 and mark multi-printer support as contributor-gated future work. Add Known limitations section to README covering cancel being disabled, macOS Docker-only, P1S-only testing, and missing LAN / Windows-native support.


### PR DESCRIPTION
Closes #192, #193, #194.

Soft-launch readiness pass on the two docs that new visitors read first. The prior state is misleading in ways that would cost credibility — the ROADMAP still lists shipped work as \"In Progress\", and until this PR the README's Bridge Setup section recommended the native binary on macOS even though \`_find_local_bridge()\` hard-codes \`None\` for Darwin.

## ROADMAP.md — full rewrite

### What changed

- **Shipped** section replaces the old v0.2.0–v0.4.0 \"planned\" blocks. Pulled straight from CHANGELOG.md with a one-line theme per version:
  - v0.4.1 — daemon HTTP API, Docker-on-macOS, signed-app gate investigation
  - v0.4.0 — Rust bridge CLI parity, daemon-backed \`status -w\`
  - v0.3.x — Typer/Rich TUI parity, \`bambox cancel\`, credential path cleanup
  - v0.2.x — \`pack\` pipeline, \`repack\`, \`login\`, \`validate\`, bridge hardening
  - v0.1.0 — initial release
- **Tested hardware** line added near the top: \"developed and validated against a Bambu P1S with AMS — that's the only hardware the maintainers have in the loop.\"
- **Future** section replaces the old \"v0.4.0 Planned / v1.0 Sketch\" blocks. Each entry explains the *condition* that would unblock scheduling it, not a date.
- **Multi-printer support** is explicitly kept on the roadmap, but moved to Future with a \"contributor-gated\" framing. Matches the scope change discussed on #193 — we don't want to drop the goal, we just can't validate anything without external testers.
- **Current focus** section calls out soft-launch readiness (this PR, the e2e quickstart, the release workflow fix #198) without overcommitting.

### What stayed

- Vision section unchanged
- Architecture north star unchanged
- \"What bambox is NOT\" spirit preserved but folded into the Future section (Moonraker, profile editing)

## README.md — targeted surgical edits

### Known limitations section (new)

Added immediately after the experimental warning, before \"Package plain G-code…\". Six bullets:

1. **Only P1S+AMS is tested** — with a contributor ask for other models
2. **\`bambox cancel\` is disabled** — link to \`docs/signed-app-gate.md\`
3. **macOS always uses the Docker bridge** — explains *why* (same signing gate)
4. **No LAN mode** — links #91
5. **No Windows native bridge** — Docker required
6. **v0.4.1 is not on PyPI yet** — explains the release-workflow no-op and links #198

Placing it at the top (after the warning, before any marketing copy) is deliberate: readers hit the caveats before they \`pip install\`. Better to lose a user who wasn't a fit than to watch them discover cancel-is-broken mid-print.

### Bridge Setup section (fixed)

Option A previously said \"(recommended, Linux x86_64 and macOS)\". The \`_find_local_bridge()\` function in \`bridge.py\` has returned \`None\` on macOS since #187 because the macOS \`libbambu_networking.dylib\` enforces the same signing gate that blocks \`cancel\` — so the native binary install is dead code on Mac and shouldn't be recommended.

- Option A is now \"Linux x86_64 only\"
- Option B explicitly says it's the **only** supported option on macOS, Windows, and Linux ARM64
- Cross-linked to Known limitations for the why

The platform table on lines 94–102 was already correct (presumably fixed in #191 alongside the cancel-hide work) — this PR just brings the prose around it into agreement.

## What's NOT in this PR

- **Quickstart walkthrough + checked-in sample G-code** — #196, separate PR
- **bambox doctor** — #197, post-0.5
- **ROADMAP changes beyond the soft-launch concern** — deliberately stayed out of adjacent cleanup (e.g. I didn't rewrite the Vision section even though I'd phrase it differently)

## Pre-PR checks

- \`uv run ruff check src tests\` — All checks passed
- \`uv run ruff format --check src tests\` — 36 files already formatted
- \`uv run mypy src/bambox\` — no issues in 17 source files
- \`uv run pytest\` — 588 passed, 40 skipped

No test fixtures assert against ROADMAP or README content (verified by grep).

## Review asks

- **#193 reframing:** does the Future section's \"contributor-gated\" framing match your intent, or do you want it higher-prominence (e.g. a dedicated callout rather than a bullet inside Future)?
- **v0.4.1 PyPI note in the limitations section:** this is accurate but slightly uncomfortable to have in the top-of-README caveats. Happy to remove it once the pending release workflow fix is verified by shipping 0.4.2. Flag it if you'd rather not mention it at all.
- **Towncrier fragment type:** used \`.misc\` since this is pure docs. If you'd rather it be \`.bugfix\` (the old ROADMAP was arguably a bug), easy change.