### PR TITLE
Release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ This changelog is managed by [towncrier](https://towncrier.readthedocs.io/).
 
 <!-- towncrier release notes start -->
 
+## 0.4.2 — 2026-04-14
+
+### Features
+
+- Ask for user confirmation of AMS tray mapping before sending a print; skip with ``--yes`` / ``-y``
+
+### Bugfixes
+
+- Release workflow now detects squash-merged release PRs by querying the PR by number, surviving auto-deleted head branches.
+
+### Misc
+
+- Rewrite ROADMAP.md to reflect shipped v0.2–v0.4.1 and mark multi-printer support as contributor-gated future work. Add Known limitations section to README covering cancel being disabled, macOS Docker-only, P1S-only testing, and missing LAN / Windows-native support.
+- Sync uv.lock with pyproject.toml — the lockfile had bambox at 0.3.0 while the project was at 0.4.1.
+- Update README: add daemon commands, fix macOS platform support, add missing modules, hide broken cancel command.
+
+
 ## 0.4.1 — 2026-04-13
 
 ### Features

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bambox-bridge"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "Rust bridge daemon for Bambu Lab printers via libbambu_networking.so"
 license = "MIT"

--- a/changes/+ams-confirm.feature
+++ b/changes/+ams-confirm.feature
@@ -1,1 +1,0 @@
-Ask for user confirmation of AMS tray mapping before sending a print; skip with ``--yes`` / ``-y``

--- a/changes/+release-detection-pr-lookup.bugfix
+++ b/changes/+release-detection-pr-lookup.bugfix
@@ -1,1 +1,0 @@
-Release workflow now detects squash-merged release PRs by querying the PR by number, surviving auto-deleted head branches.

--- a/changes/+soft-launch-docs.misc
+++ b/changes/+soft-launch-docs.misc
@@ -1,1 +1,0 @@
-Rewrite ROADMAP.md to reflect shipped v0.2–v0.4.1 and mark multi-printer support as contributor-gated future work. Add Known limitations section to README covering cancel being disabled, macOS Docker-only, P1S-only testing, and missing LAN / Windows-native support.

--- a/changes/+update-readme.misc
+++ b/changes/+update-readme.misc
@@ -1,1 +1,0 @@
-Update README: add daemon commands, fix macOS platform support, add missing modules, hide broken cancel command.

--- a/changes/+uv-lock-sync.misc
+++ b/changes/+uv-lock-sync.misc
@@ -1,1 +1,0 @@
-Sync uv.lock with pyproject.toml — the lockfile had bambox at 0.3.0 while the project was at 0.4.1.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/bambox"]
 
 [project]
 name = "bambox"
-version = "0.4.1"
+version = "0.4.2"
 description = "Package plain G-code into Bambu Lab .gcode.3mf files"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Release v0.4.2


### Features

- Ask for user confirmation of AMS tray mapping before sending a print; skip with ``--yes`` / ``-y``

### Bugfixes

- Release workflow now detects squash-merged release PRs by querying the PR by number, surviving auto-deleted head branches.

### Misc

- Rewrite ROADMAP.md to reflect shipped v0.2–v0.4.1 and mark multi-printer support as contributor-gated future work. Add Known limitations section to README covering cancel being disabled, macOS Docker-only, P1S-only testing, and missing LAN / Windows-native support.
- Sync uv.lock with pyproject.toml — the lockfile had bambox at 0.3.0 while the project was at 0.4.1.
- Update README: add daemon commands, fix macOS platform support, add missing modules, hide broken cancel command.

---
**Merge this PR to trigger the release pipeline.**
The release workflow will build the package, validate on TestPyPI, create the tag, create the GitHub Release, then publish to PyPI.