### PR TITLE
fix: compute max_layer_z from toolpath instead of unsafe default

### DIFF
--- a/changes/203.bugfix
+++ b/changes/203.bugfix
@@ -1,0 +1,1 @@
+Fix unsafe ``max_layer_z`` default (0.4mm) that caused the nozzle to crash into tall prints at end of Cura-assembled G-code.

--- a/src/bambox/cli.py
+++ b/src/bambox/cli.py
@@ -622,14 +622,7 @@ def pack(
         if len(filament_types) > 1:
             toolpath = rewrite_tool_changes(toolpath, project_settings, machine)
 
-        ctx = build_template_context(headers, project_settings)
-
-        from bambox.cura import first_layer_bbox
-
-        bbox = first_layer_bbox(toolpath)
-        if bbox:
-            ctx["first_layer_print_min"] = bbox[0]
-            ctx["first_layer_print_size"] = bbox[1]
+        ctx = build_template_context(headers, project_settings, toolpath=toolpath)
 
         start = render_template(f"{machine}_start.gcode.j2", ctx)
         end = render_template(f"{machine}_end.gcode.j2", ctx)

--- a/src/bambox/cura.py
+++ b/src/bambox/cura.py
@@ -214,12 +214,16 @@ def strip_bambox_header(gcode: str) -> str:
 def build_template_context(
     headers: dict[str, str],
     project_settings: dict[str, object],
+    toolpath: str | None = None,
 ) -> dict[str, object]:
     """Build a Jinja2 template context from BAMBOX headers + project_settings.
 
     Combines header values (concrete temps from CuraEngine) with the full
     project_settings blob (which contains per-filament arrays). Header values
     take precedence for the keys they specify.
+
+    When *toolpath* is provided, ``max_layer_z`` and ``first_layer_print_*``
+    are derived from actual G-code moves instead of using fallback defaults.
     """
     ctx: dict[str, object] = {}
 
@@ -276,6 +280,16 @@ def build_template_context(
         raw = headers["BED_TYPE"]
         ctx["curr_bed_type"] = _BED_TYPE_DISPLAY.get(raw, raw)
 
+    # Derive values from toolpath when available
+    if toolpath is not None:
+        mz = max_layer_z(toolpath)
+        if mz is not None:
+            ctx["max_layer_z"] = mz
+        bbox = first_layer_bbox(toolpath)
+        if bbox:
+            ctx["first_layer_print_min"] = bbox[0]
+            ctx["first_layer_print_size"] = bbox[1]
+
     # Defaults needed by templates
     ctx.setdefault("initial_extruder", 0)
     ctx.setdefault("max_layer_z", 0.4)
@@ -286,12 +300,29 @@ def build_template_context(
     ctx.setdefault("nozzle_temperature_range_high", [240])
     ctx.setdefault("filament_area", _FILAMENT_AREA)
 
+    # Pad single-element array defaults to match extruder count
+    extruder_count = int(headers.get("EXTRUDERS", 1))
+    for key in ("filament_max_volumetric_speed", "nozzle_temperature_range_high"):
+        val = ctx[key]
+        if isinstance(val, list) and len(val) < extruder_count:
+            ctx[key] = val + [val[-1]] * (extruder_count - len(val))
+
     return ctx
 
 
 # ---------------------------------------------------------------------------
 # First-layer bounding box (for adaptive bed leveling)
 # ---------------------------------------------------------------------------
+
+
+def max_layer_z(gcode: str) -> float | None:
+    """Return the highest Z coordinate from G0/G1 moves, or ``None``."""
+    best: float | None = None
+    for m in re.finditer(r"G[01]\s.*?Z([\d.]+)", gcode):
+        z = float(m.group(1))
+        if best is None or z > best:
+            best = z
+    return best
 
 
 def first_layer_bbox(gcode: str) -> tuple[list[float], list[float]] | None:

--- a/src/bambox/gcode_compat.py
+++ b/src/bambox/gcode_compat.py
@@ -335,6 +335,9 @@ def rewrite_tool_changes(
         if z > max_z:
             max_z = z
 
+    if max_z == 0.0:
+        log.warning("No Z moves found in toolpath; max_layer_z=0 may cause unsafe moves")
+
     # Detect initial extruder: if the first T command appears before any
     # extrusion move (G1 ... E), it's an extruder select, not a tool change.
     first_extrusion = re.search(r"G1\s.*E[\d.]", toolpath)

--- a/tests/test_cura.py
+++ b/tests/test_cura.py
@@ -12,9 +12,23 @@ from bambox.cura import (
     build_template_context,
     cura_definitions_dir,
     extract_slice_stats,
+    max_layer_z,
     parse_bambox_headers,
     strip_bambox_header,
 )
+
+
+class TestMaxLayerZ:
+    def test_returns_highest_z(self) -> None:
+        gcode = "G0 Z0.3\nG1 X10 Y10 E1\nG0 Z5.0\nG1 X20 Y20 E2\nG0 Z10.0\nG1 X30 Y30 E3\n"
+        assert max_layer_z(gcode) == 10.0
+
+    def test_returns_none_for_no_z_moves(self) -> None:
+        assert max_layer_z("G1 X10 Y10 E1\n") is None
+
+    def test_handles_z_in_g1(self) -> None:
+        gcode = "G1 Z0.4 F600\nG1 Z7.2 F600\n"
+        assert max_layer_z(gcode) == 7.2
 
 
 class TestCuraDefinitions:


### PR DESCRIPTION
## Summary

- **`max_layer_z` default of 0.4mm caused nozzle crashes** — the end gcode moved Z to 0.9mm absolute, driving into any part taller than ~0.5mm. Confirmed on a real Cura P1S print.
- Move `max_layer_z` and `first_layer_bbox` computation into `build_template_context(toolpath=)` so the CLI no longer patches template context manually.
- Add `max_layer_z()` G-code scanner in `cura.py`.
- Pad single-element temperature arrays to match extruder count (fixes `nozzle_temperature_range_high` producing `M109 S` with no value for extruder > 0).
- Warn when `gcode_compat` finds no Z moves in toolpath.

Closes #203

## Test plan

- [x] New unit tests for `max_layer_z()` function (3 cases)
- [x] All 591 existing tests pass
- [x] Lint, format, mypy all clean
- [ ] Re-run the Cura P1S cube example and verify end gcode has correct Z value

🤖 Generated with [Claude Code](https://claude.com/claude-code)