### PR TITLE
refactor: move G-code assembly logic from cli.py to cura.py

### DIFF
--- a/changes/204.misc
+++ b/changes/204.misc
@@ -1,0 +1,1 @@
+Move G-code assembly logic from ``cli.py`` into ``cura.assemble_cura_gcode()`` to respect module ownership boundaries.

--- a/src/bambox/cli.py
+++ b/src/bambox/cli.py
@@ -16,10 +16,9 @@ from rich.markup import escape
 from bambox import ui
 from bambox.cura import (
     PRINTER_MODEL_IDS,
-    build_template_context,
+    assemble_cura_gcode,
     extract_slice_stats,
     parse_bambox_headers,
-    strip_bambox_header,
 )
 from bambox.pack import FilamentInfo, SliceInfo, pack_gcode_3mf, repack_3mf
 from bambox.settings import available_filaments, available_machines, build_project_settings
@@ -613,20 +612,9 @@ def pack(
 
     # If BAMBOX_ASSEMBLE=true, render start/end templates and wrap toolpath
     if headers.get("ASSEMBLE") == "true":
-        from bambox.assemble import assemble_gcode
-        from bambox.gcode_compat import rewrite_tool_changes
-        from bambox.templates import render_template
-
-        toolpath = strip_bambox_header(gcode_str)
-
-        if len(filament_types) > 1:
-            toolpath = rewrite_tool_changes(toolpath, project_settings, machine)
-
-        ctx = build_template_context(headers, project_settings, toolpath=toolpath)
-
-        start = render_template(f"{machine}_start.gcode.j2", ctx)
-        end = render_template(f"{machine}_end.gcode.j2", ctx)
-        gcode_bytes = assemble_gcode(start, toolpath, end).encode()
+        gcode_bytes = assemble_cura_gcode(
+            gcode_str, project_settings, machine, filament_types, headers
+        )
         if headers:
             ui.info(f"Auto-configured from BAMBOX headers: {machine}, {filament_types}")
 

--- a/src/bambox/cura.py
+++ b/src/bambox/cura.py
@@ -502,3 +502,42 @@ def extract_slice_stats(gcode: str, flush_volume_mm3: float = 280.0) -> SliceSta
             stats.prediction += n_purges * _PURGE_TIME_SECS
 
     return stats
+
+
+# ---------------------------------------------------------------------------
+# High-level G-code assembly
+# ---------------------------------------------------------------------------
+
+
+def assemble_cura_gcode(
+    gcode_str: str,
+    project_settings: dict[str, object],
+    machine: str,
+    filament_types: list[str],
+    headers: dict[str, str],
+) -> bytes:
+    """Assemble raw CuraEngine G-code into Bambu-ready output.
+
+    Takes CuraEngine G-code with ``BAMBOX_ASSEMBLE=true`` headers and:
+
+    1. Strips the BAMBOX header block.
+    2. Rewrites tool-change sequences for multi-filament prints.
+    3. Renders machine-specific start/end G-code templates.
+    4. Assembles start + toolpath + end into final G-code.
+
+    Returns the assembled G-code as UTF-8 bytes ready for 3MF packaging.
+    """
+    from bambox.assemble import assemble_gcode
+    from bambox.gcode_compat import rewrite_tool_changes
+    from bambox.templates import render_template
+
+    toolpath = strip_bambox_header(gcode_str)
+
+    if len(filament_types) > 1:
+        toolpath = rewrite_tool_changes(toolpath, project_settings, machine)
+
+    ctx = build_template_context(headers, project_settings, toolpath=toolpath)
+
+    start = render_template(f"{machine}_start.gcode.j2", ctx)
+    end = render_template(f"{machine}_end.gcode.j2", ctx)
+    return assemble_gcode(start, toolpath, end).encode()


### PR DESCRIPTION
## Summary
- Extract G-code processing logic (BAMBOX header stripping, tool-change rewriting, template rendering, start/end assembly) from `cli.py`'s `pack` command into a new `cura.assemble_cura_gcode()` function.
- `cli.py` now delegates to this single function call, enforcing the module ownership rule that CLI modules only handle argument parsing and user-facing output.

Closes #204

## Test plan
- [ ] All 591 existing tests pass (verified locally)
- [ ] `ruff check`, `ruff format --check`, and `mypy` all pass with zero errors
- [ ] `bambox pack` with BAMBOX_ASSEMBLE=true G-code produces identical output to before the refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)