### PR TITLE
feat: BAMBOX_CREDENTIALS_TOML env var for credential-less deployments

### DIFF
--- a/changes/215.feature
+++ b/changes/215.feature
@@ -1,0 +1,1 @@
+Support ``BAMBOX_CREDENTIALS_TOML`` env var holding the full credentials TOML content, for CI and container deployments where writing a file is awkward.

--- a/src/bambox/credentials.py
+++ b/src/bambox/credentials.py
@@ -46,6 +46,17 @@ def mask_serial(serial: str) -> str:
     return "*" * (len(serial) - 4) + serial[-4:]
 
 
+def _credentials_source() -> str:
+    """Describe where credentials are loaded from (for error messages).
+
+    Returns either the env var name (when ``BAMBOX_CREDENTIALS_TOML`` is set)
+    or the resolved file path.
+    """
+    if "BAMBOX_CREDENTIALS_TOML" in os.environ:
+        return "BAMBOX_CREDENTIALS_TOML env var"
+    return str(_credentials_path())
+
+
 def _credentials_path() -> Path:
     """Return the path to the credentials file.
 
@@ -89,12 +100,21 @@ def _credentials_path() -> Path:
 
 
 def _load_raw() -> dict:
-    """Load the raw credentials TOML, or return empty dict if not found."""
+    """Load the raw credentials TOML, or return empty dict if not found.
+
+    When ``BAMBOX_CREDENTIALS_TOML`` is set, its value is parsed as TOML
+    content directly (useful for CI / containers where writing a file is
+    awkward).  Otherwise the file at :func:`_credentials_path` is read.
+    """
+    import tomllib
+
+    env_toml = os.environ.get("BAMBOX_CREDENTIALS_TOML")
+    if env_toml is not None:
+        return tomllib.loads(env_toml)
+
     path = _credentials_path()
     if not path.exists():
         return {}
-    import tomllib
-
     with open(path, "rb") as f:
         return tomllib.load(f)
 
@@ -117,7 +137,15 @@ def _write_credentials(data: dict) -> None:
     Uses ``os.open()`` with explicit mode so the file is never world-readable,
     even briefly.  Manual TOML writer (tomllib is read-only, no tomli_w
     dependency).
+
+    Raises when ``BAMBOX_CREDENTIALS_TOML`` is set — env-var mode is
+    read-only; writes would not persist across runs.
     """
+    if "BAMBOX_CREDENTIALS_TOML" in os.environ:
+        raise RuntimeError(
+            "Cannot save credentials: BAMBOX_CREDENTIALS_TOML is set (read-only mode). "
+            "Unset it or use BAMBOX_CREDENTIALS to point to a writable file."
+        )
     path = _credentials_path()
     if sys.platform != "win32":
         path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
@@ -199,13 +227,14 @@ def load_printer_credentials(name: str) -> dict[str, str]:
     raw = _load_raw()
     if not raw:
         raise RuntimeError(
-            f"Credentials file not found: {_credentials_path()}\nRun 'bambox login' to create it."
+            f"Credentials not found: {_credentials_source()}\n"
+            "Run 'bambox login' or set BAMBOX_CREDENTIALS_TOML to create credentials."
         )
     printers = raw.get("printers", {})
     if name not in printers:
         available = list(printers.keys())
         raise RuntimeError(
-            f"Printer '{name}' not found in {_credentials_path()}. Available: {available}"
+            f"Printer '{name}' not found in {_credentials_source()}. Available: {available}"
         )
     creds = dict(printers[name])
 

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -11,6 +11,7 @@ import pytest
 from bambox.credentials import (
     _cache_dir,
     _credentials_path,
+    _credentials_source,
     _escape_toml_value,
     _load_raw,
     _quote_toml_key,
@@ -23,6 +24,15 @@ from bambox.credentials import (
     save_cloud_credentials,
     save_printer,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_credentials_env(monkeypatch):
+    """Prevent user's shell env from leaking into tests."""
+    monkeypatch.delenv("BAMBOX_CREDENTIALS_TOML", raising=False)
+    monkeypatch.delenv("BAMBOX_CREDENTIALS", raising=False)
+    monkeypatch.delenv("ESTAMPO_CREDENTIALS", raising=False)
+    monkeypatch.delenv("BAMBU_SERIAL", raising=False)
 
 
 class TestCacheDir:
@@ -313,7 +323,7 @@ class TestLoadPrinterCredentials:
         cred_path = tmp_path / "nonexistent" / "credentials.toml"
         monkeypatch.setattr("bambox.credentials._credentials_path", lambda: cred_path)
 
-        with pytest.raises(RuntimeError, match="Credentials file not found"):
+        with pytest.raises(RuntimeError, match="Credentials not found"):
             load_printer_credentials("myprinter")
 
     def test_printer_not_found_raises(self, tmp_path, monkeypatch):
@@ -380,3 +390,84 @@ class TestCloudTokenJson:
 
         with cloud_token_json() as path:
             assert path.stat().st_mode & 0o777 == 0o600
+
+
+class TestCredentialsTomlEnvVar:
+    """BAMBOX_CREDENTIALS_TOML holds the full TOML content in-memory."""
+
+    def test_loads_from_env_var(self, monkeypatch):
+        monkeypatch.setenv(
+            "BAMBOX_CREDENTIALS_TOML",
+            '[cloud]\ntoken = "env-tok"\nrefresh_token = "env-ref"\n'
+            'email = "env@test.com"\nuid = "42"\n',
+        )
+        cloud = load_cloud_credentials()
+        assert cloud is not None
+        assert cloud["token"] == "env-tok"
+        assert cloud["email"] == "env@test.com"
+
+    def test_env_var_overrides_file(self, tmp_path, monkeypatch):
+        cred_path = tmp_path / "credentials.toml"
+        cred_path.write_text('[cloud]\ntoken = "file-tok"\n')
+        monkeypatch.setattr("bambox.credentials._credentials_path", lambda: cred_path)
+        monkeypatch.setenv("BAMBOX_CREDENTIALS_TOML", '[cloud]\ntoken = "env-tok"\n')
+
+        cloud = load_cloud_credentials()
+        assert cloud is not None
+        assert cloud["token"] == "env-tok"
+
+    def test_env_var_with_printers(self, monkeypatch):
+        monkeypatch.setenv(
+            "BAMBOX_CREDENTIALS_TOML",
+            '[printers.workshop]\ntype = "bambu-cloud"\nserial = "SN999"\n',
+        )
+        creds = load_printer_credentials("workshop")
+        assert creds["serial"] == "SN999"
+
+    def test_cloud_token_json_from_env_var(self, monkeypatch):
+        monkeypatch.setenv(
+            "BAMBOX_CREDENTIALS_TOML",
+            '[cloud]\ntoken = "envtok"\nrefresh_token = "envref"\nemail = "e@e.com"\nuid = "1"\n',
+        )
+        with cloud_token_json() as path:
+            assert path.exists()
+            data = json.loads(path.read_text())
+            assert data["token"] == "envtok"
+            assert data["refreshToken"] == "envref"
+
+    def test_save_cloud_raises_in_env_var_mode(self, monkeypatch):
+        monkeypatch.setenv("BAMBOX_CREDENTIALS_TOML", '[cloud]\ntoken = "tok"\n')
+        with pytest.raises(RuntimeError, match="BAMBOX_CREDENTIALS_TOML"):
+            save_cloud_credentials(token="new", refresh_token="new", email="a@b.com", uid="1")
+
+    def test_save_printer_raises_in_env_var_mode(self, monkeypatch):
+        monkeypatch.setenv("BAMBOX_CREDENTIALS_TOML", "")
+        with pytest.raises(RuntimeError, match="BAMBOX_CREDENTIALS_TOML"):
+            save_printer("new", {"type": "bambu-cloud", "serial": "SN"})
+
+    def test_empty_env_var_yields_empty_dict(self, monkeypatch):
+        monkeypatch.setenv("BAMBOX_CREDENTIALS_TOML", "")
+        assert _load_raw() == {}
+        assert load_cloud_credentials() is None
+
+    def test_invalid_toml_raises(self, monkeypatch):
+        import tomllib
+
+        monkeypatch.setenv("BAMBOX_CREDENTIALS_TOML", "not = valid = toml")
+        with pytest.raises(tomllib.TOMLDecodeError):
+            _load_raw()
+
+    def test_credentials_source_reports_env_var(self, monkeypatch):
+        monkeypatch.setenv("BAMBOX_CREDENTIALS_TOML", "")
+        assert _credentials_source() == "BAMBOX_CREDENTIALS_TOML env var"
+
+    def test_credentials_source_reports_path_when_unset(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("BAMBOX_CREDENTIALS_TOML", raising=False)
+        cred_path = tmp_path / "credentials.toml"
+        monkeypatch.setattr("bambox.credentials._credentials_path", lambda: cred_path)
+        assert _credentials_source() == str(cred_path)
+
+    def test_error_message_mentions_env_var_source(self, monkeypatch):
+        monkeypatch.setenv("BAMBOX_CREDENTIALS_TOML", "")
+        with pytest.raises(RuntimeError, match="BAMBOX_CREDENTIALS_TOML env var"):
+            load_printer_credentials("nonexistent")


### PR DESCRIPTION
## Summary

- Adds `BAMBOX_CREDENTIALS_TOML` env var that holds the full `credentials.toml` content in memory — no file on disk required.
- `_write_credentials()` raises cleanly in env-var mode (writes wouldn't persist), so `bambox login` / `save_*` fail fast rather than silently losing data.
- New `_credentials_source()` helper keeps error messages accurate when the source is the env var rather than a file path.

Motivated by estampo/estampo#486 — once bambox-bridge is bundled into the estampo Docker image, this closes the last gap for slice-and-print from a GitHub Actions workflow: stash the whole TOML as one GHA secret and export it.

```yaml
env:
  BAMBOX_CREDENTIALS_TOML: ${{ secrets.BAMBOX_CREDENTIALS_TOML }}
steps:
  - run: bambox print model.gcode.3mf --printer p1s-living-room
```

Precedence:
1. `BAMBOX_CREDENTIALS_TOML` (in-memory TOML content) — new
2. `BAMBOX_CREDENTIALS` (path) — existing
3. `ESTAMPO_CREDENTIALS` (path) — existing backward compat
4. Default config paths — existing

Bridge materialisation is unchanged — `write_token_json()` still writes a 0o600 tempfile for the bridge binary to read.

Closes #215

## Test plan
- [x] `uv run ruff check src tests` — passes
- [x] `uv run ruff format --check src tests` — passes
- [x] `uv run mypy src/bambox` — passes
- [x] `uv run pytest --ignore=tests/test_e2e_cura_vs_bbl.py` — 528 passed (e2e failures are pre-existing from #214, unrelated)
- [x] New tests cover: env-var load path, env-var-over-file precedence, printer lookup from env var, token JSON generation, write failure in env-var mode, empty env var → empty dict, invalid TOML raises, `_credentials_source()` reports correctly