### PR TITLE
fix: repack passes machine flag through and patches printer_model_id

### DIFF
--- a/changes/212.bugfix
+++ b/changes/212.bugfix
@@ -1,0 +1,1 @@
+Pass ``-m`` machine flag through to ``repack_3mf`` even when ``-f`` is not provided.

--- a/changes/213.bugfix
+++ b/changes/213.bugfix
@@ -1,0 +1,1 @@
+``repack`` now patches ``printer_model_id`` in ``slice_info.config`` from the ``-m`` machine flag.

--- a/src/bambox/cli.py
+++ b/src/bambox/cli.py
@@ -647,7 +647,7 @@ def repack(
     else:
         filament_types = None
         filament_colors = None
-    real_machine = machine if filament_types else None
+    real_machine = machine
 
     try:
         repack_3mf(

--- a/src/bambox/pack.py
+++ b/src/bambox/pack.py
@@ -398,6 +398,15 @@ def fixup_model_settings(xml: str, min_slots: int = MIN_SLOTS) -> str:
     return result
 
 
+def _patch_slice_info_printer_model(xml_str: str, printer_model_id: str) -> str:
+    """Replace the printer_model_id value in slice_info.config XML."""
+    return re.sub(
+        r'(<metadata key="printer_model_id" value=")[^"]*(")',
+        rf"\g<1>{printer_model_id}\g<2>",
+        xml_str,
+    )
+
+
 def repack_3mf(
     path: Path,
     *,
@@ -480,6 +489,19 @@ def repack_3mf(
                 f'    <metadata key="pattern_bbox_file" value="{_PLATE_JSON_PATH}"/>\n  </plate>',
             )
 
+        # --- Fix slice_info.config (printer_model_id) ---
+        try:
+            si_raw = zin.read("Metadata/slice_info.config").decode()
+        except KeyError:
+            si_raw = None
+        si_patched: str | None = None
+        if si_raw is not None and machine:
+            from bambox.cura import PRINTER_MODEL_IDS
+
+            model_id = PRINTER_MODEL_IDS.get(machine.lower(), "")
+            if model_id:
+                si_patched = _patch_slice_info_printer_model(si_raw, model_id)
+
         # --- Fix thumbnails ---
         thumb_files = [
             "Metadata/plate_1.png",
@@ -528,6 +550,8 @@ def repack_3mf(
                     zout.writestr(item, json.dumps(ps, indent=4) + "\n")
                 elif item.filename == "Metadata/model_settings.config" and ms_patched:
                     zout.writestr(item, ms_patched)
+                elif item.filename == "Metadata/slice_info.config" and si_patched:
+                    zout.writestr(item, si_patched)
                 else:
                     zout.writestr(item, zin.read(item.filename))
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -283,7 +283,16 @@ class TestCmdRepack:
         with patch("bambox.cli.repack_3mf") as mock_repack:
             main(["repack", str(threemf)])
             mock_repack.assert_called_once()
-            assert mock_repack.call_args[1]["machine"] is None
+            assert mock_repack.call_args[1]["machine"] == "p1s"
+
+    def test_repack_machine_without_filament(self, tmp_path: Path) -> None:
+        threemf = tmp_path / "test.gcode.3mf"
+        threemf.write_bytes(b"fake")
+
+        with patch("bambox.cli.repack_3mf") as mock_repack:
+            main(["repack", str(threemf), "-m", "x1c"])
+            assert mock_repack.call_args[1]["machine"] == "x1c"
+            assert mock_repack.call_args[1]["filaments"] is None
 
     def test_repack_with_filament(self, tmp_path: Path) -> None:
         threemf = tmp_path / "test.gcode.3mf"

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -672,6 +672,64 @@ class TestRepack3mf:
             assert "filament_colors" in plate_data
             assert plate_data["version"] == 2
 
+    def test_repack_patches_printer_model_id(self, tmp_path: Path) -> None:
+        """repack with machine should patch printer_model_id in slice_info.config."""
+        from bambox.pack import repack_3mf
+
+        slice_info_xml = (
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            "<config><plate>\n"
+            '<metadata key="printer_model_id" value=""/>\n'
+            '<metadata key="prediction" value="100"/>\n'
+            "</plate></config>"
+        )
+        out = self._make_3mf(
+            tmp_path,
+            **{"Metadata/slice_info.config": slice_info_xml.encode()},
+        )
+        repack_3mf(out, machine="p1s")
+        with zipfile.ZipFile(out) as z:
+            si = z.read("Metadata/slice_info.config").decode()
+            assert 'value="C12"' in si
+
+    def test_repack_patches_printer_model_id_x1c(self, tmp_path: Path) -> None:
+        """repack with machine=x1c should set printer_model_id to BL-P001."""
+        from bambox.pack import repack_3mf
+
+        slice_info_xml = (
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            "<config><plate>\n"
+            '<metadata key="printer_model_id" value="wrong"/>\n'
+            "</plate></config>"
+        )
+        out = self._make_3mf(
+            tmp_path,
+            **{"Metadata/slice_info.config": slice_info_xml.encode()},
+        )
+        repack_3mf(out, machine="x1c")
+        with zipfile.ZipFile(out) as z:
+            si = z.read("Metadata/slice_info.config").decode()
+            assert 'value="BL-P001"' in si
+
+    def test_repack_no_machine_preserves_slice_info(self, tmp_path: Path) -> None:
+        """repack without machine should not modify slice_info.config."""
+        from bambox.pack import repack_3mf
+
+        slice_info_xml = (
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            "<config><plate>\n"
+            '<metadata key="printer_model_id" value="original"/>\n'
+            "</plate></config>"
+        )
+        out = self._make_3mf(
+            tmp_path,
+            **{"Metadata/slice_info.config": slice_info_xml.encode()},
+        )
+        repack_3mf(out)
+        with zipfile.ZipFile(out) as z:
+            si = z.read("Metadata/slice_info.config").decode()
+            assert 'value="original"' in si
+
 
 # ---------------------------------------------------------------------------
 # File output


### PR DESCRIPTION
## Summary
- **#212**: `-m` machine flag was gated on `-f` filament being present — now passed through unconditionally so fixup-only repacks respect the machine
- **#213**: `repack_3mf()` now patches `printer_model_id` in `slice_info.config` using the machine→model ID mapping (e.g. p1s→C12, x1c→BL-P001)

Closes #212, closes #213.

## Test plan
- [x] Existing test updated: `test_repack_basic` now asserts machine="p1s" (default) instead of None
- [x] New test: `test_repack_machine_without_filament` — verifies -m without -f passes through
- [x] New test: `test_repack_patches_printer_model_id` — p1s→C12
- [x] New test: `test_repack_patches_printer_model_id_x1c` — x1c→BL-P001
- [x] New test: `test_repack_no_machine_preserves_slice_info` — no machine leaves original value

🤖 Generated with [Claude Code](https://claude.com/claude-code)