### PR TITLE
feat: pre-packaging G-code safety validation (S001-S003)

### DIFF
--- a/changes/207.feature
+++ b/changes/207.feature
@@ -1,0 +1,1 @@
+Add pre-packaging G-code safety validation (S001–S003) to catch dangerous Z moves, premature heater shutdown, and extrusion before homing.

--- a/src/bambox/cli.py
+++ b/src/bambox/cli.py
@@ -821,6 +821,9 @@ def print_cmd(
     yes: Annotated[
         bool, typer.Option("-y", "--yes", help="Skip AMS mapping confirmation prompt")
     ] = False,
+    force: Annotated[
+        bool, typer.Option("--force", help="Send even if validation finds errors")
+    ] = False,
 ) -> None:
     """Send a .gcode.3mf to a Bambu printer via cloud bridge."""
     _warn_experimental()
@@ -829,6 +832,23 @@ def print_cmd(
     if not threemf.exists():
         ui.error(f"{threemf} not found")
         sys.exit(1)
+
+    # Validate the archive before sending to the printer
+    from bambox.validate import validate_3mf
+
+    val_result = validate_3mf(threemf)
+    for f in val_result.warnings:
+        ui.warn(f"[{f.code}] {f.message}")
+    for f in val_result.errors:
+        ui.error(f"[{f.code}] {f.message}")
+        if f.detail:
+            ui.error(f"  {f.detail}")
+    if not val_result.valid:
+        if force:
+            ui.warn("Validation errors found — proceeding anyway (--force)")
+        else:
+            ui.error("Validation failed. Use --force to send anyway.")
+            sys.exit(1)
 
     creds_path = credentials
     try:

--- a/src/bambox/cli.py
+++ b/src/bambox/cli.py
@@ -510,6 +510,9 @@ def pack(
     nozzle_diameter: Annotated[
         float, typer.Option("--nozzle-diameter", help="Nozzle diameter in mm")
     ] = 0.4,
+    skip_safety: Annotated[
+        bool, typer.Option("--skip-safety", help="Skip pre-packaging G-code safety checks")
+    ] = False,
 ) -> None:
     """Package G-code into .gcode.3mf."""
     _warn_experimental()
@@ -608,6 +611,21 @@ def pack(
     except ValueError as e:
         ui.error(str(e))
         sys.exit(1)
+
+    if not skip_safety:
+        from bambox.validate import validate_gcode
+
+        safety_result = validate_gcode(gcode_str)
+        if not safety_result.valid:
+            for f in safety_result.findings:
+                if f.severity.value == "error":
+                    ui.error(f"[{f.code}] {f.message}")
+                    if f.detail:
+                        ui.error(f"  {f.detail}")
+            ui.error("G-code safety check failed. Use --skip-safety to override.")
+            sys.exit(1)
+        for f in safety_result.warnings:
+            ui.warn(f"[{f.code}] {f.message}")
 
     pack_gcode_3mf(gcode_bytes, real_output, slice_info=info, project_settings=project_settings)
     ui.success(f"Wrote {real_output} ({real_output.stat().st_size} bytes)")

--- a/src/bambox/validate.py
+++ b/src/bambox/validate.py
@@ -73,6 +73,15 @@ _RE_M620_S = re.compile(r"^M620 S(\d+)", re.MULTILINE)
 _RE_M621_S = re.compile(r"^M621 S(\d+)", re.MULTILINE)
 _RE_BARE_TOOL = re.compile(r"^T([0-4])\s*$", re.MULTILINE)
 
+# G-code safety regex patterns
+_RE_LAYER_CHANGE = re.compile(r"^;LAYER_CHANGE", re.MULTILINE)
+_RE_LAYER_Z = re.compile(r"^;Z:([\d.]+)", re.MULTILINE)
+_RE_G1_Z = re.compile(r"^G[01]\s+.*Z([\d.]+)", re.MULTILINE)
+_RE_G1_Z_ONLY = re.compile(r"^G[01]\s+Z([\d.]+)", re.MULTILINE)
+_RE_TEMP_ZERO = re.compile(r"^M(10[49]|1[49]0)\s+S0(?:\s|$)", re.MULTILINE)
+_RE_G28 = re.compile(r"^G28\b", re.MULTILINE)
+_RE_EXTRUSION = re.compile(r"^G[01]\s+.*E[\d.]+", re.MULTILINE)
+
 
 # ---------------------------------------------------------------------------
 # Data structures
@@ -175,6 +184,25 @@ def validate_3mf_buffer(buf: IO[bytes]) -> ValidationResult:
         if gcode is not None and slice_info is not None:
             _check_time_sync(gcode, slice_info, findings)
 
+    return ValidationResult(findings)
+
+
+def validate_gcode(gcode: str) -> ValidationResult:
+    """Validate assembled G-code for physically dangerous moves before packaging.
+
+    This is a pre-packaging safety check — separate from the archive-level
+    validation in ``validate_3mf``.  It catches dangerous patterns that could
+    damage the printer or cause failed prints.
+
+    Checks:
+        S001: End G-code Z move lower than ``max_layer_z`` (nozzle crash risk)
+        S002: ``M104``/``M109``/``M140`` S0 in toolpath (premature heater off)
+        S003: Extrusion before homing (``G28``)
+    """
+    findings: list[Finding] = []
+    _check_end_z_safety(gcode, findings)
+    _check_premature_heater_off(gcode, findings)
+    _check_extrusion_before_homing(gcode, findings)
     return ValidationResult(findings)
 
 
@@ -480,6 +508,111 @@ def _check_multi_filament(gcode: str, findings: list[Finding]) -> None:
                     )
                 )
                 return  # one finding is enough
+
+
+# ---------------------------------------------------------------------------
+# G-code safety checks (pre-packaging)
+# ---------------------------------------------------------------------------
+
+
+def _extract_max_layer_z(gcode: str) -> float:
+    """Find the highest Z from ;Z: layer-change comments."""
+    z_values = _RE_LAYER_Z.findall(gcode)
+    if not z_values:
+        return 0.0
+    return max(float(z) for z in z_values)
+
+
+def _find_end_gcode_start(gcode: str) -> int:
+    """Return the character offset where end G-code begins.
+
+    Heuristic: the position after the last ;LAYER_CHANGE block's content.
+    Falls back to end-of-string if no layer changes found.
+    """
+    matches = list(_RE_LAYER_CHANGE.finditer(gcode))
+    if not matches:
+        return len(gcode)
+    # End gcode starts after the last layer's moves.  We look for the last
+    # M73 L marker which signals end-of-layer, then scan forward.
+    last_m73_l = None
+    for m in _RE_M73_L.finditer(gcode):
+        last_m73_l = m
+    if last_m73_l:
+        return last_m73_l.end()
+    return matches[-1].end()
+
+
+def _check_end_z_safety(gcode: str, findings: list[Finding]) -> None:
+    """S001: End G-code Z move lower than max_layer_z (nozzle crash risk)."""
+    max_z = _extract_max_layer_z(gcode)
+    if max_z <= 0:
+        return  # can't check without layer Z data
+
+    end_start = _find_end_gcode_start(gcode)
+    end_section = gcode[end_start:]
+
+    for line in end_section.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(";"):
+            continue
+        m = _RE_G1_Z_ONLY.match(stripped)
+        if m:
+            z_val = float(m.group(1))
+            if z_val < max_z:
+                findings.append(
+                    Finding(
+                        Severity.ERROR,
+                        "S001",
+                        f"End G-code moves Z to {z_val}mm, below max layer Z "
+                        f"of {max_z}mm (nozzle crash risk)",
+                        stripped[:120],
+                    )
+                )
+                return  # one finding is enough
+
+
+def _check_premature_heater_off(gcode: str, findings: list[Finding]) -> None:
+    """S002: M104/M109/M140 S0 in toolpath section (premature heater shutdown)."""
+    end_start = _find_end_gcode_start(gcode)
+    toolpath_section = gcode[:end_start]
+
+    for line in toolpath_section.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(";"):
+            continue
+        if _RE_TEMP_ZERO.match(stripped):
+            findings.append(
+                Finding(
+                    Severity.ERROR,
+                    "S002",
+                    "Heater set to 0 during toolpath (premature shutdown)",
+                    stripped[:120],
+                )
+            )
+            return  # one finding is enough
+
+
+def _check_extrusion_before_homing(gcode: str, findings: list[Finding]) -> None:
+    """S003: Extrusion move (G1 with E) before any G28 homing command."""
+    homing_match = _RE_G28.search(gcode)
+    if not homing_match:
+        return  # no homing found — different problem, not our check
+
+    # Check if any extrusion happens before the first G28
+    for line in gcode[: homing_match.start()].splitlines():
+        stripped = line.strip()
+        if stripped.startswith(";"):
+            continue
+        if _RE_EXTRUSION.match(stripped):
+            findings.append(
+                Finding(
+                    Severity.ERROR,
+                    "S003",
+                    "Extrusion move before homing (G28)",
+                    stripped[:120],
+                )
+            )
+            return  # one finding is enough
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -328,6 +328,14 @@ class TestCmdRepack:
 
 
 class TestCmdPrint:
+    @pytest.fixture(autouse=True)
+    def _skip_validation(self) -> ...:  # type: ignore[override]
+        """Most print tests use fake archives — bypass validate_3mf."""
+        from bambox.validate import ValidationResult
+
+        with patch("bambox.validate.validate_3mf", return_value=ValidationResult()):
+            yield
+
     def test_print_missing_file(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         missing = tmp_path / "nope.gcode.3mf"
         with patch("bambox.bridge.load_credentials", return_value={"token": "t"}):
@@ -489,6 +497,66 @@ class TestCmdPrint:
         ):
             main(["print", str(threemf), "-d", "SER", "--timeout", "300"])
             assert mock_cp.call_args[1]["timeout"] == 300
+
+
+class TestPrintValidation:
+    """Tests for pre-print archive validation gate."""
+
+    def test_print_blocks_on_validation_error(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from bambox.validate import Finding, Severity, ValidationResult
+
+        threemf = tmp_path / "test.gcode.3mf"
+        threemf.write_bytes(b"fake")
+        bad_result = ValidationResult([Finding(Severity.ERROR, "E000", "Not a valid ZIP file")])
+        with (
+            patch("bambox.validate.validate_3mf", return_value=bad_result),
+            patch("bambox.bridge.load_credentials", return_value={"token": "t"}),
+        ):
+            with pytest.raises(SystemExit, match="1"):
+                main(["print", str(threemf), "-d", "SER"])
+        err = capsys.readouterr().err
+        assert "E000" in err
+        assert "--force" in err
+
+    def test_print_force_overrides_validation(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from bambox.validate import Finding, Severity, ValidationResult
+
+        threemf = tmp_path / "test.gcode.3mf"
+        threemf.write_bytes(b"fake")
+        bad_result = ValidationResult([Finding(Severity.ERROR, "E000", "Not a valid ZIP file")])
+        with (
+            patch("bambox.validate.validate_3mf", return_value=bad_result),
+            patch("bambox.bridge.load_credentials", return_value={"token": "t"}),
+            patch("bambox.bridge.cloud_print", return_value={"result": "sent"}),
+        ):
+            main(["print", str(threemf), "-d", "SER", "--force"])
+        combined = capsys.readouterr()
+        assert "proceeding anyway" in combined.err
+        assert "successfully" in combined.out
+
+    def test_print_warnings_shown_but_not_blocked(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from bambox.validate import Finding, Severity, ValidationResult
+
+        threemf = tmp_path / "test.gcode.3mf"
+        threemf.write_bytes(b"fake")
+        warn_result = ValidationResult(
+            [Finding(Severity.WARNING, "W001", "printer_model_id is empty")]
+        )
+        with (
+            patch("bambox.validate.validate_3mf", return_value=warn_result),
+            patch("bambox.bridge.load_credentials", return_value={"token": "t"}),
+            patch("bambox.bridge.cloud_print", return_value={"result": "sent"}),
+        ):
+            main(["print", str(threemf), "-d", "SER"])
+        combined = capsys.readouterr()
+        assert "W001" in combined.err
+        assert "successfully" in combined.out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -21,6 +21,7 @@ from bambox.validate import (
     compare_3mf,
     validate_3mf,
     validate_3mf_buffer,
+    validate_gcode,
 )
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures" / "e2e_cura_p1s"
@@ -916,3 +917,135 @@ class TestCLIReference:
         a = build_valid_3mf(tmp_path)
         with pytest.raises(SystemExit, match="1"):
             main(["validate", str(a), "--reference", str(tmp_path / "nope.3mf")])
+
+
+# ---------------------------------------------------------------------------
+# G-code safety validation (pre-packaging)
+# ---------------------------------------------------------------------------
+
+# A safe G-code with proper homing, layers, and end Z above max_layer_z
+_SAFE_GCODE = """\
+G28
+; HEADER_BLOCK_START
+; total layer number: 2
+; HEADER_BLOCK_END
+M73 P0 R5
+;LAYER_CHANGE
+;Z:0.2
+;HEIGHT:0.2
+M73 L1
+M991 S0 P1
+G1 X10 Y10 E1 F600
+;LAYER_CHANGE
+;Z:0.4
+;HEIGHT:0.2
+M73 L2
+M991 S0 P2
+G1 X20 Y20 E2 F600
+; end gcode
+G1 Z50
+M104 S0
+M140 S0
+"""
+
+
+class TestValidateGcode:
+    def test_safe_gcode_passes(self) -> None:
+        result = validate_gcode(_SAFE_GCODE)
+        assert result.valid
+        assert len(result.errors) == 0
+
+    def test_s001_end_z_below_max_layer_z(self) -> None:
+        gcode = """\
+G28
+;LAYER_CHANGE
+;Z:0.2
+M73 L1
+M991 S0 P1
+G1 X10 Y10 E1 F600
+;LAYER_CHANGE
+;Z:10.0
+M73 L2
+M991 S0 P2
+G1 X20 Y20 E2 F600
+G1 Z5.0
+"""
+        result = validate_gcode(gcode)
+        assert not result.valid
+        codes = [f.code for f in result.errors]
+        assert "S001" in codes
+
+    def test_s001_end_z_above_max_layer_z_ok(self) -> None:
+        gcode = """\
+G28
+;LAYER_CHANGE
+;Z:0.2
+M73 L1
+M991 S0 P1
+;LAYER_CHANGE
+;Z:10.0
+M73 L2
+M991 S0 P2
+G1 Z50.0
+"""
+        result = validate_gcode(gcode)
+        s001_errors = [f for f in result.errors if f.code == "S001"]
+        assert len(s001_errors) == 0
+
+    def test_s002_premature_heater_off_in_toolpath(self) -> None:
+        gcode = """\
+G28
+;LAYER_CHANGE
+;Z:0.2
+M73 L1
+M991 S0 P1
+M104 S0
+;LAYER_CHANGE
+;Z:0.4
+M73 L2
+M991 S0 P2
+"""
+        result = validate_gcode(gcode)
+        assert not result.valid
+        codes = [f.code for f in result.errors]
+        assert "S002" in codes
+
+    def test_s002_heater_off_in_end_section_ok(self) -> None:
+        result = validate_gcode(_SAFE_GCODE)
+        s002_errors = [f for f in result.errors if f.code == "S002"]
+        assert len(s002_errors) == 0
+
+    def test_s003_extrusion_before_homing(self) -> None:
+        gcode = """\
+G1 X10 Y10 E1 F600
+G28
+;LAYER_CHANGE
+;Z:0.2
+M73 L1
+M991 S0 P1
+"""
+        result = validate_gcode(gcode)
+        assert not result.valid
+        codes = [f.code for f in result.errors]
+        assert "S003" in codes
+
+    def test_s003_extrusion_after_homing_ok(self) -> None:
+        result = validate_gcode(_SAFE_GCODE)
+        s003_errors = [f for f in result.errors if f.code == "S003"]
+        assert len(s003_errors) == 0
+
+    def test_no_layer_data_skips_z_check(self) -> None:
+        gcode = "G28\nG1 X10 Y10 E1 F600\n"
+        result = validate_gcode(gcode)
+        s001_errors = [f for f in result.errors if f.code == "S001"]
+        assert len(s001_errors) == 0
+
+    def test_minimal_gcode_fixture_passes(self) -> None:
+        """MINIMAL_GCODE from shared fixtures should not trigger safety errors."""
+        result = validate_gcode(MINIMAL_GCODE)
+        # MINIMAL_GCODE has no G28, so S003 won't fire (no homing = nothing to check)
+        # S001/S002 should not fire either
+        s001 = [f for f in result.errors if f.code == "S001"]
+        s002 = [f for f in result.errors if f.code == "S002"]
+        assert len(s001) == 0
+        assert len(s002) == 0


### PR DESCRIPTION
## Summary
- Adds `validate_gcode()` to `validate.py` with three safety checks that run before packaging:
  - **S001**: End G-code Z move below `max_layer_z` — catches nozzle crash bugs like #203
  - **S002**: `M104`/`M109`/`M140` S0 in toolpath section — catches premature heater shutdown
  - **S003**: Extrusion move (`G1 ... E`) before `G28` homing — catches unhomed moves
- Integrated into `bambox pack` command — blocks packaging on safety errors
- New `--skip-safety` flag to override when needed

Closes #207.

## Test plan
- [x] `test_safe_gcode_passes` — clean G-code with proper structure passes all checks
- [x] `test_s001_end_z_below_max_layer_z` — Z move below max triggers S001
- [x] `test_s001_end_z_above_max_layer_z_ok` — Z move above max is fine
- [x] `test_s002_premature_heater_off_in_toolpath` — M104 S0 in toolpath triggers S002
- [x] `test_s002_heater_off_in_end_section_ok` — M104 S0 in end section is fine
- [x] `test_s003_extrusion_before_homing` — extrusion before G28 triggers S003
- [x] `test_s003_extrusion_after_homing_ok` — extrusion after G28 is fine
- [x] `test_no_layer_data_skips_z_check` — gracefully skips when no ;Z: markers
- [x] `test_minimal_gcode_fixture_passes` — existing MINIMAL_GCODE fixture is safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)