### PR TITLE
Release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ This changelog is managed by [towncrier](https://towncrier.readthedocs.io/).
 
 <!-- towncrier release notes start -->
 
+## 0.4.3 — 2026-04-18
+
+### Features
+
+- Add pre-packaging G-code safety validation (S001–S003) to catch dangerous Z moves, premature heater shutdown, and extrusion before homing. ([#207](https://github.com/estampo/bambox/pull/207))
+- Add native single-extruder CuraEngine P1S definition (``bambox_p1s``) with complete start/end G-code — no bambox post-processing required. Remove the ``bambox_p1s_ams`` multi-extruder definition and the G-code assembly/tool-change rewriting pipeline (see ADR-003). ([#210](https://github.com/estampo/bambox/pull/210))
+- Support ``BAMBOX_CREDENTIALS_TOML`` env var holding the full credentials TOML content, for CI and container deployments where writing a file is awkward. ([#215](https://github.com/estampo/bambox/pull/215))
+
+### Bugfixes
+
+- Fix unsafe ``max_layer_z`` default (0.4mm) that caused the nozzle to crash into tall prints at end of Cura-assembled G-code. ([#203](https://github.com/estampo/bambox/pull/203))
+- Pass ``-m`` machine flag through to ``repack_3mf`` even when ``-f`` is not provided. ([#212](https://github.com/estampo/bambox/pull/212))
+- ``repack`` now patches ``printer_model_id`` in ``slice_info.config`` from the ``-m`` machine flag. ([#213](https://github.com/estampo/bambox/pull/213))
+
+### Misc
+
+- Move G-code assembly logic from ``cli.py`` into ``cura.assemble_cura_gcode()`` to respect module ownership boundaries. ([#204](https://github.com/estampo/bambox/pull/204))
+- Move P1S CuraEngine printer definition to its own repo (estampo/cura-p1s)
+
+
 ## 0.4.2 — 2026-04-14
 
 ### Features

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bambox-bridge"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 description = "Rust bridge daemon for Bambu Lab printers via libbambu_networking.so"
 license = "MIT"

--- a/changes/+move-p1s-definition.misc
+++ b/changes/+move-p1s-definition.misc
@@ -1,1 +1,0 @@
-Move P1S CuraEngine printer definition to its own repo (estampo/cura-p1s)

--- a/changes/203.bugfix
+++ b/changes/203.bugfix
@@ -1,1 +1,0 @@
-Fix unsafe ``max_layer_z`` default (0.4mm) that caused the nozzle to crash into tall prints at end of Cura-assembled G-code.

--- a/changes/204.misc
+++ b/changes/204.misc
@@ -1,1 +1,0 @@
-Move G-code assembly logic from ``cli.py`` into ``cura.assemble_cura_gcode()`` to respect module ownership boundaries.

--- a/changes/207.feature
+++ b/changes/207.feature
@@ -1,1 +1,0 @@
-Add pre-packaging G-code safety validation (S001–S003) to catch dangerous Z moves, premature heater shutdown, and extrusion before homing.

--- a/changes/210.feature
+++ b/changes/210.feature
@@ -1,1 +1,0 @@
-Add native single-extruder CuraEngine P1S definition (``bambox_p1s``) with complete start/end G-code — no bambox post-processing required. Remove the ``bambox_p1s_ams`` multi-extruder definition and the G-code assembly/tool-change rewriting pipeline (see ADR-003).

--- a/changes/212.bugfix
+++ b/changes/212.bugfix
@@ -1,1 +1,0 @@
-Pass ``-m`` machine flag through to ``repack_3mf`` even when ``-f`` is not provided.

--- a/changes/213.bugfix
+++ b/changes/213.bugfix
@@ -1,1 +1,0 @@
-``repack`` now patches ``printer_model_id`` in ``slice_info.config`` from the ``-m`` machine flag.

--- a/changes/215.feature
+++ b/changes/215.feature
@@ -1,1 +1,0 @@
-Support ``BAMBOX_CREDENTIALS_TOML`` env var holding the full credentials TOML content, for CI and container deployments where writing a file is awkward.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/bambox"]
 
 [project]
 name = "bambox"
-version = "0.4.2"
+version = "0.4.3"
 description = "Package plain G-code into Bambu Lab .gcode.3mf files"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Release v0.4.3


### Features

- Add pre-packaging G-code safety validation (S001–S003) to catch dangerous Z moves, premature heater shutdown, and extrusion before homing. ([#207](https://github.com/estampo/bambox/pull/207))
- Add native single-extruder CuraEngine P1S definition (``bambox_p1s``) with complete start/end G-code — no bambox post-processing required. Remove the ``bambox_p1s_ams`` multi-extruder definition and the G-code assembly/tool-change rewriting pipeline (see ADR-003). ([#210](https://github.com/estampo/bambox/pull/210))
- Support ``BAMBOX_CREDENTIALS_TOML`` env var holding the full credentials TOML content, for CI and container deployments where writing a file is awkward. ([#215](https://github.com/estampo/bambox/pull/215))

### Bugfixes

- Fix unsafe ``max_layer_z`` default (0.4mm) that caused the nozzle to crash into tall prints at end of Cura-assembled G-code. ([#203](https://github.com/estampo/bambox/pull/203))
- Pass ``-m`` machine flag through to ``repack_3mf`` even when ``-f`` is not provided. ([#212](https://github.com/estampo/bambox/pull/212))
- ``repack`` now patches ``printer_model_id`` in ``slice_info.config`` from the ``-m`` machine flag. ([#213](https://github.com/estampo/bambox/pull/213))

### Misc

- Move G-code assembly logic from ``cli.py`` into ``cura.assemble_cura_gcode()`` to respect module ownership boundaries. ([#204](https://github.com/estampo/bambox/pull/204))
- Move P1S CuraEngine printer definition to its own repo (estampo/cura-p1s)

---
**Merge this PR to trigger the release pipeline.**
The release workflow will build the package, validate on TestPyPI, create the tag, create the GitHub Release, then publish to PyPI.