### PR TITLE
fix: avoid false positive S002 on heater-off after last extrusion

### DIFF
--- a/changes/222.bugfix
+++ b/changes/222.bugfix
@@ -1,0 +1,1 @@
+Fix false positive S002 safety check on heater-off commands after last extrusion move.

--- a/src/bambox/validate.py
+++ b/src/bambox/validate.py
@@ -573,23 +573,19 @@ def _check_end_z_safety(gcode: str, findings: list[Finding]) -> None:
 
 def _check_premature_heater_off(gcode: str, findings: list[Finding]) -> None:
     """S002: M104/M109/M140 S0 in toolpath section (premature heater shutdown)."""
-    end_start = _find_end_gcode_start(gcode)
-    toolpath_section = gcode[:end_start]
-
-    for line in toolpath_section.splitlines():
-        stripped = line.strip()
-        if stripped.startswith(";"):
+    for m in _RE_TEMP_ZERO.finditer(gcode):
+        # If no extrusion moves follow, the toolpath is complete — not premature.
+        if not _RE_EXTRUSION.search(gcode, m.end()):
             continue
-        if _RE_TEMP_ZERO.match(stripped):
-            findings.append(
-                Finding(
-                    Severity.ERROR,
-                    "S002",
-                    "Heater set to 0 during toolpath (premature shutdown)",
-                    stripped[:120],
-                )
+        findings.append(
+            Finding(
+                Severity.ERROR,
+                "S002",
+                "Heater set to 0 during toolpath (premature shutdown)",
+                m.group()[:120],
             )
-            return  # one finding is enough
+        )
+        return  # one finding is enough
 
 
 def _check_extrusion_before_homing(gcode: str, findings: list[Finding]) -> None:

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1004,6 +1004,7 @@ M104 S0
 ;Z:0.4
 M73 L2
 M991 S0 P2
+G1 X20 Y20 E2 F600
 """
         result = validate_gcode(gcode)
         assert not result.valid
@@ -1012,6 +1013,29 @@ M991 S0 P2
 
     def test_s002_heater_off_in_end_section_ok(self) -> None:
         result = validate_gcode(_SAFE_GCODE)
+        s002_errors = [f for f in result.errors if f.code == "S002"]
+        assert len(s002_errors) == 0
+
+    def test_s002_heater_off_after_last_extrusion_ok(self) -> None:
+        """M140 S0 right after the last extrusion move is not premature (#222)."""
+        gcode = """\
+G28
+;LAYER_CHANGE
+;Z:0.2
+M73 L1
+M991 S0 P1
+G1 X10 Y10 E1 F600
+;LAYER_CHANGE
+;Z:0.4
+M73 L2
+M991 S0 P2
+G1 F1500 E1877.70409
+M140 S0
+M107
+G1 Z50
+M104 S0
+"""
+        result = validate_gcode(gcode)
         s002_errors = [f for f in result.errors if f.code == "S002"]
         assert len(s002_errors) == 0
 


### PR DESCRIPTION
## Summary
- S002 now checks whether any extrusion moves (`G1` with `E`) follow the heater-off command, rather than relying solely on the `M73 L` / `;LAYER_CHANGE` end-gcode heuristic
- If no extrusion follows, the toolpath is complete and the heater-off is not premature — no finding emitted
- Adds regression test for the exact scenario from #222

Closes #222.

## Test plan
- [x] New test `test_s002_heater_off_after_last_extrusion_ok` passes
- [x] Existing S002 test updated to include extrusion after heater-off (true positive still caught)
- [x] All 79 validate tests pass
- [x] ruff check, ruff format, mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)