### PR TITLE
Release v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ This changelog is managed by [towncrier](https://towncrier.readthedocs.io/).
 
 <!-- towncrier release notes start -->
 
+## 0.4.4 — 2026-04-18
+
+### Features
+
+- Release pipeline now automatically creates an issue on ``estampo/estampo`` when a full (non-prerelease) bambox version is published to PyPI.
+
+### Bugfixes
+
+- Docker bridge images now tagged with bambox version (``vX.Y.Z``) and ``latest`` in addition to the Bambu SDK version. Fixed broken release skip guard that used an unreliable GitHub API call. ([#202](https://github.com/estampo/bambox/pull/202))
+- Fix false positive S002 safety check on heater-off commands after last extrusion move. ([#222](https://github.com/estampo/bambox/pull/222))
+
+
 ## 0.4.3 — 2026-04-18
 
 ### Features

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bambox-bridge"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 description = "Rust bridge daemon for Bambu Lab printers via libbambu_networking.so"
 license = "MIT"

--- a/changes/+notify-estampo.feature
+++ b/changes/+notify-estampo.feature
@@ -1,1 +1,0 @@
-Release pipeline now automatically creates an issue on ``estampo/estampo`` when a full (non-prerelease) bambox version is published to PyPI.

--- a/changes/202.bugfix
+++ b/changes/202.bugfix
@@ -1,1 +1,0 @@
-Docker bridge images now tagged with bambox version (``vX.Y.Z``) and ``latest`` in addition to the Bambu SDK version. Fixed broken release skip guard that used an unreliable GitHub API call.

--- a/changes/222.bugfix
+++ b/changes/222.bugfix
@@ -1,1 +1,0 @@
-Fix false positive S002 safety check on heater-off commands after last extrusion move.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/bambox"]
 
 [project]
 name = "bambox"
-version = "0.4.3"
+version = "0.4.4"
 description = "Package plain G-code into Bambu Lab .gcode.3mf files"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Release v0.4.4


### Features

- Release pipeline now automatically creates an issue on ``estampo/estampo`` when a full (non-prerelease) bambox version is published to PyPI.

### Bugfixes

- Docker bridge images now tagged with bambox version (``vX.Y.Z``) and ``latest`` in addition to the Bambu SDK version. Fixed broken release skip guard that used an unreliable GitHub API call. ([#202](https://github.com/estampo/bambox/pull/202))
- Fix false positive S002 safety check on heater-off commands after last extrusion move. ([#222](https://github.com/estampo/bambox/pull/222))

---
**Merge this PR to trigger the release pipeline.**
The release workflow will build the package, validate on TestPyPI, create the tag, create the GitHub Release, then publish to PyPI.