### PR TITLE
docs: fix credentials path in README (#229)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Authenticate with Bambu Cloud and save printer credentials.
 bambox login
 ```
 
-Credentials are stored in `~/.config/estampo/credentials.toml`.
+Credentials are stored in `~/.config/bambox/credentials.toml`.
 
 ### `bambox print` — Send to printer
 
@@ -367,7 +367,7 @@ from bambox.validate import validate_3mf
 | `assemble` | G-code component assembly (start + toolpath + end) |
 | `thumbnail` | G-code-to-PNG rendering (top-down view) |
 | `toolpath` | Synthetic toolpath generation for testing |
-| `credentials` | Credential loading and storage (`~/.config/estampo/credentials.toml`) |
+| `credentials` | Credential loading and storage (`~/.config/bambox/credentials.toml`) |
 | `auth` | Bambu Cloud authentication |
 | `gcode_compat` | G-code rewriting for multi-filament compatibility |
 | `ui` | Rich console formatting, color swatches, interactive prompts |

--- a/changes/229.bugfix
+++ b/changes/229.bugfix
@@ -1,0 +1,1 @@
+Fix README documenting the wrong credentials path (`~/.config/estampo/...` → `~/.config/bambox/...`); the code already used the correct path.


### PR DESCRIPTION
## Summary
- README documented `~/.config/estampo/credentials.toml` but the code (`credentials.py`) and the estampo ecosystem use `~/.config/bambox/credentials.toml`. Users following the README wrote creds to the wrong path.
- Fixes two README references; code was already correct.

Closes #229

## Test plan
- [x] `grep -rn 'config/estampo/credentials' README.md` returns nothing
- [x] ruff/mypy/pytest green

🤖 Generated with [Claude Code](https://claude.com/claude-code)