### PR TITLE
feat: fail loudly on printer/profile mismatch at pack entry (#226)

### DIFF
--- a/changes/226.feature
+++ b/changes/226.feature
@@ -1,0 +1,1 @@
+`bambox pack` and `bambox repack` now fail loudly at entry when the requested printer has no bundled profile, no firmware model-ID mapping, or a malformed base profile — surfacing the problem at pack time rather than as a cryptic firmware rejection at print time.

--- a/src/bambox/cli.py
+++ b/src/bambox/cli.py
@@ -20,7 +20,12 @@ from bambox.cura import (
     parse_bambox_headers,
 )
 from bambox.pack import FilamentInfo, SliceInfo, pack_gcode_3mf, repack_3mf
-from bambox.settings import available_filaments, available_machines, build_project_settings
+from bambox.settings import (
+    available_filaments,
+    available_machines,
+    build_project_settings,
+    validate_printer_profile,
+)
 
 log = logging.getLogger(__name__)
 
@@ -550,6 +555,16 @@ def pack(
     else:
         assigned = _assign_filament_slots(_parse_filament_args(filament))
 
+    # Pre-flight: make sure the printer we resolved (CLI flag or header)
+    # has a well-formed bundled profile before doing any real work. This
+    # surfaces unknown / malformed printers at pack time rather than at
+    # print time with a cryptic firmware error.
+    try:
+        validate_printer_profile(machine)
+    except ValueError as e:
+        ui.error(str(e))
+        sys.exit(1)
+
     filament_types = [f[1] for f in assigned]
     filament_colors = [f[2] for f in assigned]
 
@@ -666,6 +681,12 @@ def repack(
         filament_types = None
         filament_colors = None
     real_machine = machine
+
+    try:
+        validate_printer_profile(real_machine)
+    except ValueError as e:
+        ui.error(str(e))
+        sys.exit(1)
 
     try:
         repack_3mf(

--- a/src/bambox/settings.py
+++ b/src/bambox/settings.py
@@ -60,6 +60,61 @@ def _machine_profile_path(machine: str) -> Path:
     return path
 
 
+# Keys every bundled machine base profile is expected to contain. A profile
+# missing these can still technically be loaded, but packing will produce a
+# ``.gcode.3mf`` the printer firmware rejects — we'd rather fail at pack time.
+REQUIRED_BASE_PROFILE_KEYS: frozenset[str] = frozenset(
+    {
+        "printer_model",
+        "printer_variant",
+        "printer_settings_id",
+        "nozzle_diameter",
+        "printable_area",
+    }
+)
+
+
+def validate_printer_profile(machine: str) -> None:
+    """Validate that ``machine`` has a usable, well-formed bundled profile.
+
+    This is the single pack-time pre-flight check for the requested printer.
+    It catches three distinct failure modes before any archive is produced:
+
+    1. No ``base_<machine>.json`` profile exists for the requested printer
+       (``--machine`` value or ``BAMBOX_PRINTER=`` header refers to an
+       unsupported printer).
+    2. A profile exists but the printer has no entry in
+       :data:`bambox.cura.PRINTER_MODEL_IDS` — packing would embed an empty
+       ``printer_model_id`` in the archive, which the firmware rejects.
+    3. A profile exists but is missing keys in
+       :data:`REQUIRED_BASE_PROFILE_KEYS` — the settings blob would be
+       incomplete and the firmware would reject it at print time.
+
+    Raises:
+        ValueError: with a message naming the offending piece and, where
+            useful, the set of supported printers.
+    """
+    from bambox.cura import PRINTER_MODEL_IDS
+
+    avail = available_machines()
+    if machine not in avail:
+        raise ValueError(f"Unknown printer '{machine}'. Supported printers: {sorted(avail)}")
+
+    if machine.lower() not in PRINTER_MODEL_IDS:
+        raise ValueError(
+            f"Printer '{machine}' has a bundled profile but no entry in "
+            f"bambox.cura.PRINTER_MODEL_IDS. Add the firmware model ID "
+            f"mapping before packing."
+        )
+
+    profile = _load_json(_machine_profile_path(machine))
+    missing = sorted(REQUIRED_BASE_PROFILE_KEYS - set(profile.keys()))
+    if missing:
+        raise ValueError(
+            f"Printer profile '{machine}' is malformed: missing required key(s) {missing}"
+        )
+
+
 def build_project_settings(
     filaments: list[str],
     *,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -182,6 +183,7 @@ class TestCmdPack:
         with (
             patch("bambox.cli.pack_gcode_3mf", side_effect=_touch_output_side_effect),
             patch("bambox.cli.build_project_settings", return_value={}) as mock_settings,
+            patch("bambox.cli.validate_printer_profile"),
         ):
             main(["pack", str(gcode), "-m", "a1mini"])
             assert mock_settings.call_args[1]["machine"] == "a1mini"
@@ -206,6 +208,7 @@ class TestCmdPack:
         with (
             patch("bambox.cli.pack_gcode_3mf", side_effect=_touch_output_side_effect),
             patch("bambox.cli.build_project_settings", return_value={}) as mock_settings,
+            patch("bambox.cli.validate_printer_profile"),
         ):
             main(["pack", str(gcode)])
             assert mock_settings.call_args[1]["machine"] == "a1mini"
@@ -240,6 +243,45 @@ class TestCmdPack:
             with pytest.raises(SystemExit, match="1"):
                 main(["pack", str(gcode)])
         assert "bad machine" in capsys.readouterr().err
+
+    def test_pack_unknown_printer_no_artifact(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Unknown printer → clean error + no artifact produced (#226)."""
+        gcode = tmp_path / "test.gcode"
+        gcode.write_text("G28\n")
+        output = tmp_path / "test.gcode.3mf"
+
+        with pytest.raises(SystemExit, match="1"):
+            main(["pack", str(gcode), "-o", str(output), "-m", "nonexistent_printer"])
+        err = capsys.readouterr().err
+        assert "Unknown printer 'nonexistent_printer'" in err
+        assert "p1s" in err
+        assert not output.exists()
+
+    def test_pack_malformed_profile_names_key(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Known printer, malformed profile → error names the missing key(s) (#226)."""
+        gcode = tmp_path / "test.gcode"
+        gcode.write_text("G28\n")
+        output = tmp_path / "test.gcode.3mf"
+
+        profiles_dir = tmp_path / "profiles"
+        profiles_dir.mkdir()
+        # Intentionally missing printer_variant, printer_settings_id, etc.
+        (profiles_dir / "base_broken.json").write_text(json.dumps({"printer_model": "Broken"}))
+
+        with (
+            patch("bambox.settings._DATA_DIR", profiles_dir),
+            patch("bambox.cura.PRINTER_MODEL_IDS", {"broken": "XYZ"}),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            main(["pack", str(gcode), "-o", str(output), "-m", "broken"])
+        err = capsys.readouterr().err
+        assert "malformed" in err
+        assert "printer_variant" in err
+        assert not output.exists()
 
     def test_pack_nozzle_and_model_id(self, tmp_path: Path) -> None:
         gcode = tmp_path / "test.gcode"
@@ -289,7 +331,10 @@ class TestCmdRepack:
         threemf = tmp_path / "test.gcode.3mf"
         threemf.write_bytes(b"fake")
 
-        with patch("bambox.cli.repack_3mf") as mock_repack:
+        with (
+            patch("bambox.cli.repack_3mf") as mock_repack,
+            patch("bambox.cli.validate_printer_profile"),
+        ):
             main(["repack", str(threemf), "-m", "x1c"])
             assert mock_repack.call_args[1]["machine"] == "x1c"
             assert mock_repack.call_args[1]["filaments"] is None
@@ -298,7 +343,10 @@ class TestCmdRepack:
         threemf = tmp_path / "test.gcode.3mf"
         threemf.write_bytes(b"fake")
 
-        with patch("bambox.cli.repack_3mf") as mock_repack:
+        with (
+            patch("bambox.cli.repack_3mf") as mock_repack,
+            patch("bambox.cli.validate_printer_profile"),
+        ):
             main(["repack", str(threemf), "-f", "PETG", "-m", "a1mini"])
             assert mock_repack.call_args[1]["filaments"] == ["PETG"]
             assert mock_repack.call_args[1]["machine"] == "a1mini"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 
 from bambox.settings import (
@@ -10,6 +14,7 @@ from bambox.settings import (
     available_filaments,
     available_machines,
     build_project_settings,
+    validate_printer_profile,
 )
 
 
@@ -104,3 +109,54 @@ class TestBuildProjectSettings:
         ft = result.get("filament_type")
         assert isinstance(ft, list)
         assert len(ft) == 3
+
+
+class TestValidatePrinterProfile:
+    def test_valid_machine_passes(self) -> None:
+        validate_printer_profile("p1s")
+
+    def test_unknown_machine_raises_with_supported_list(self) -> None:
+        with pytest.raises(ValueError) as exc:
+            validate_printer_profile("nonexistent_printer")
+        msg = str(exc.value)
+        assert "Unknown printer 'nonexistent_printer'" in msg
+        assert "p1s" in msg
+
+    def test_profile_without_model_id_mapping_raises(self, tmp_path: Path) -> None:
+        """A bundled profile without a PRINTER_MODEL_IDS entry must fail fast.
+
+        This protects against the silent empty ``printer_model_id`` path,
+        where the archive is accepted by bambox but rejected by firmware.
+        """
+        with (
+            patch("bambox.settings._DATA_DIR", tmp_path),
+            patch("bambox.cura.PRINTER_MODEL_IDS", {"p1s": "C12"}),
+        ):
+            (tmp_path / "base_foo.json").write_text(
+                json.dumps(
+                    {
+                        "printer_model": "Foo",
+                        "printer_variant": "0.4",
+                        "printer_settings_id": "Foo 0.4",
+                        "nozzle_diameter": ["0.4"],
+                        "printable_area": ["0x0"],
+                    }
+                )
+            )
+            with pytest.raises(ValueError) as exc:
+                validate_printer_profile("foo")
+            assert "PRINTER_MODEL_IDS" in str(exc.value)
+
+    def test_malformed_profile_missing_keys_raises(self, tmp_path: Path) -> None:
+        """A profile missing required keys must fail fast and name the key(s)."""
+        with (
+            patch("bambox.settings._DATA_DIR", tmp_path),
+            patch("bambox.cura.PRINTER_MODEL_IDS", {"bar": "XYZ"}),
+        ):
+            (tmp_path / "base_bar.json").write_text(json.dumps({"printer_model": "Bar"}))
+            with pytest.raises(ValueError) as exc:
+                validate_printer_profile("bar")
+            msg = str(exc.value)
+            assert "malformed" in msg
+            assert "printer_variant" in msg
+            assert "printer_settings_id" in msg


### PR DESCRIPTION
## Summary
- Adds `validate_printer_profile()` in `settings.py` that performs a three-step pre-flight: bundled profile exists → `PRINTER_MODEL_IDS` mapping exists → required base keys present.
- Called at the entry of `bambox pack` and `bambox repack` before any archive work — unknown/unmapped/malformed printers now exit 1 with a message naming the offending piece and listing supported printers.
- Tests for the three acceptance cases from the issue: unknown printer (no artifact produced), malformed profile (error names the missing key), happy path.

Note: `PRINTER_MODEL_IDS` currently lists 7 printers but only `p1s` has a bundled profile. The validator reflects this honestly — \`Supported printers: ['p1s']\`. Adding profiles for X1C/P1P/A1 is tracked separately.

Closes #226

## Test plan
- [x] \`uv run pytest\` — all green (targeted + full suite)
- [x] ruff / format / mypy clean
- [x] \`bambox pack -m nonexistent_printer\` → clean error, no artifact
- [x] \`bambox pack -m p1s\` → happy path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)