### PR TITLE
Release v0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ This changelog is managed by [towncrier](https://towncrier.readthedocs.io/).
 
 <!-- towncrier release notes start -->
 
+## 0.4.5 — 2026-04-20
+
+### Features
+
+- `bambox pack` and `bambox repack` now fail loudly at entry when the requested printer has no bundled profile, no firmware model-ID mapping, or a malformed base profile — surfacing the problem at pack time rather than as a cryptic firmware rejection at print time. ([#226](https://github.com/estampo/bambox/pull/226))
+- `bambox print` warns when the sliced G-code's `curr_bed_type` differs from the `plate_type` configured for the target printer in `credentials.toml`, helping catch first-layer nozzle-crash risk before sending the job. ([#233](https://github.com/estampo/bambox/pull/233))
+
+### Bugfixes
+
+- Fix README documenting the wrong credentials path (`~/.config/estampo/...` → `~/.config/bambox/...`); the code already used the correct path. ([#229](https://github.com/estampo/bambox/pull/229))
+- `bambox pack` now derives `printer_model_id` from the `-m/--machine` flag (via `PRINTER_MODEL_IDS`) when neither `--printer-model-id` nor a `BAMBOX_PRINTER` header is provided. Previously, callers that only passed `-m` — including estampo's CuraEngine pipeline — produced archives that tripped W001 in `bambox validate`. ([#235](https://github.com/estampo/bambox/pull/235))
+
+### Misc
+
+- Documentation: add "What bambox is — and isn't", a supported printers/filaments table, a "How packing works" explainer, and a Credits & Attribution section linking `THIRD-PARTY-NOTICES`. Ship `THIRD-PARTY-NOTICES` inside the installed wheel. ([#225](https://github.com/estampo/bambox/pull/225))
+
+
 ## 0.4.4 — 2026-04-18
 
 ### Features

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bambox-bridge"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 description = "Rust bridge daemon for Bambu Lab printers via libbambu_networking.so"
 license = "MIT"

--- a/changes/225.misc
+++ b/changes/225.misc
@@ -1,1 +1,0 @@
-Documentation: add "What bambox is — and isn't", a supported printers/filaments table, a "How packing works" explainer, and a Credits & Attribution section linking `THIRD-PARTY-NOTICES`. Ship `THIRD-PARTY-NOTICES` inside the installed wheel.

--- a/changes/226.feature
+++ b/changes/226.feature
@@ -1,1 +1,0 @@
-`bambox pack` and `bambox repack` now fail loudly at entry when the requested printer has no bundled profile, no firmware model-ID mapping, or a malformed base profile — surfacing the problem at pack time rather than as a cryptic firmware rejection at print time.

--- a/changes/229.bugfix
+++ b/changes/229.bugfix
@@ -1,1 +1,0 @@
-Fix README documenting the wrong credentials path (`~/.config/estampo/...` → `~/.config/bambox/...`); the code already used the correct path.

--- a/changes/233.feature
+++ b/changes/233.feature
@@ -1,1 +1,0 @@
-`bambox print` warns when the sliced G-code's `curr_bed_type` differs from the `plate_type` configured for the target printer in `credentials.toml`, helping catch first-layer nozzle-crash risk before sending the job.

--- a/changes/235.bugfix
+++ b/changes/235.bugfix
@@ -1,1 +1,0 @@
-`bambox pack` now derives `printer_model_id` from the `-m/--machine` flag (via `PRINTER_MODEL_IDS`) when neither `--printer-model-id` nor a `BAMBOX_PRINTER` header is provided. Previously, callers that only passed `-m` — including estampo's CuraEngine pipeline — produced archives that tripped W001 in `bambox validate`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = ["src/bambox"]
 
 [project]
 name = "bambox"
-version = "0.4.4"
+version = "0.4.5"
 description = "Package plain G-code into Bambu Lab .gcode.3mf files"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Release v0.4.5


### Features

- `bambox pack` and `bambox repack` now fail loudly at entry when the requested printer has no bundled profile, no firmware model-ID mapping, or a malformed base profile — surfacing the problem at pack time rather than as a cryptic firmware rejection at print time. ([#226](https://github.com/estampo/bambox/pull/226))
- `bambox print` warns when the sliced G-code's `curr_bed_type` differs from the `plate_type` configured for the target printer in `credentials.toml`, helping catch first-layer nozzle-crash risk before sending the job. ([#233](https://github.com/estampo/bambox/pull/233))

### Bugfixes

- Fix README documenting the wrong credentials path (`~/.config/estampo/...` → `~/.config/bambox/...`); the code already used the correct path. ([#229](https://github.com/estampo/bambox/pull/229))
- `bambox pack` now derives `printer_model_id` from the `-m/--machine` flag (via `PRINTER_MODEL_IDS`) when neither `--printer-model-id` nor a `BAMBOX_PRINTER` header is provided. Previously, callers that only passed `-m` — including estampo's CuraEngine pipeline — produced archives that tripped W001 in `bambox validate`. ([#235](https://github.com/estampo/bambox/pull/235))

### Misc

- Documentation: add "What bambox is — and isn't", a supported printers/filaments table, a "How packing works" explainer, and a Credits & Attribution section linking `THIRD-PARTY-NOTICES`. Ship `THIRD-PARTY-NOTICES` inside the installed wheel. ([#225](https://github.com/estampo/bambox/pull/225))

---
**Merge this PR to trigger the release pipeline.**
The release workflow will build the package, validate on TestPyPI, create the tag, create the GitHub Release, then publish to PyPI.