### PR TITLE
fix: bind daemon Docker port to 127.0.0.1 only (#237)

### DIFF
--- a/changes/237.bugfix
+++ b/changes/237.bugfix
@@ -1,0 +1,1 @@
+Bridge daemon Docker port is now published only on 127.0.0.1, preventing unauthenticated LAN access to the daemon's cloud-print endpoints.

--- a/src/bambox/bridge.py
+++ b/src/bambox/bridge.py
@@ -571,7 +571,7 @@ def _start_daemon_docker(token_file: Path, *, verbose: bool = False) -> bool:
         "--platform",
         "linux/amd64",
         "-p",
-        "8765:8765",
+        "127.0.0.1:8765:8765",
         "-v",
         f"{token_real}:/tmp/credentials.json:ro",
         DOCKER_IMAGE,

--- a/src/bambox/cli.py
+++ b/src/bambox/cli.py
@@ -1340,7 +1340,7 @@ def start(
                 "--platform",
                 "linux/amd64",
                 "-p",
-                "8765:8765",
+                "127.0.0.1:8765:8765",
                 "-v",
                 f"{token_real}:/tmp/credentials.json:ro",
                 DOCKER_IMAGE,

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -795,6 +795,22 @@ class TestStartDaemonDocker:
         assert DOCKER_DAEMON_CONTAINER in docker_run_cmd
         assert DOCKER_IMAGE in docker_run_cmd
 
+    def test_publishes_port_only_on_loopback(self, tmp_path):
+        token = tmp_path / "creds.json"
+        token.write_text("{}")
+        ok = subprocess.CompletedProcess([], returncode=0, stdout="", stderr="")
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(list(cmd))
+            return ok
+
+        with patch("bambox.bridge.subprocess.run", side_effect=fake_run):
+            _start_daemon_docker(token)
+        docker_run_cmd = calls[2]
+        port_idx = docker_run_cmd.index("-p")
+        assert docker_run_cmd[port_idx + 1] == "127.0.0.1:8765:8765"
+
     def test_returns_false_on_docker_run_failure(self, tmp_path):
         token = tmp_path / "creds.json"
         token.write_text("{}")


### PR DESCRIPTION
## Summary

Closes #237.

The Docker fallback for the bridge daemon was publishing port 8765 on all host interfaces (`-p 8765:8765`). Combined with the daemon's unauthenticated HTTP endpoints (`/print`, `/cancel/:device_id`, `/shutdown`, ...), anyone on the same LAN could drive the user's Bambu Cloud account. This is the default on macOS and the fallback path on Linux hosts without the local bridge binary.

- `src/bambox/bridge.py` (`_start_daemon_docker`): `-p 8765:8765` → `-p 127.0.0.1:8765:8765`
- `src/bambox/cli.py` (foreground Docker branch): same change

The container-internal `--bind 0.0.0.0` is intentionally kept — Docker's port forwarder connects to the container's eth0, so a loopback bind inside the container would not be reachable through `-p`. Restricting the host-side publish is enough to close the exposure.

## Test plan

- [x] New test `test_publishes_port_only_on_loopback` asserts the `-p` argument is `127.0.0.1:8765:8765`
- [x] `uv run ruff check src tests`
- [x] `uv run ruff format --check src tests`
- [x] `uv run mypy src/bambox`
- [x] `uv run pytest` (565 passed, 40 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)