### PR TITLE
Release v0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This changelog is managed by [towncrier](https://towncrier.readthedocs.io/).
 
 <!-- towncrier release notes start -->
 
+## 0.4.6 — 2026-04-21
+
+### Bugfixes
+
+- Bridge daemon Docker port is now published only on 127.0.0.1, preventing unauthenticated LAN access to the daemon's cloud-print endpoints. ([#237](https://github.com/estampo/bambox/pull/237))
+
+
 ## 0.4.5 — 2026-04-20
 
 ### Features

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bambox-bridge"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 description = "Rust bridge daemon for Bambu Lab printers via libbambu_networking.so"
 license = "MIT"

--- a/changes/237.bugfix
+++ b/changes/237.bugfix
@@ -1,1 +1,0 @@
-Bridge daemon Docker port is now published only on 127.0.0.1, preventing unauthenticated LAN access to the daemon's cloud-print endpoints.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = ["src/bambox"]
 
 [project]
 name = "bambox"
-version = "0.4.5"
+version = "0.4.6"
 description = "Package plain G-code into Bambu Lab .gcode.3mf files"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Release v0.4.6


### Bugfixes

- Bridge daemon Docker port is now published only on 127.0.0.1, preventing unauthenticated LAN access to the daemon's cloud-print endpoints. ([#237](https://github.com/estampo/bambox/pull/237))

---
**Merge this PR to trigger the release pipeline.**
The release workflow will build the package, validate on TestPyPI, create the tag, create the GitHub Release, then publish to PyPI.