### PR TITLE
fix: generate RGBA thumbnails at 512×512 for Bambu UI compatibility

### DIFF
--- a/changes/241.bugfix
+++ b/changes/241.bugfix
@@ -1,0 +1,1 @@
+Thumbnails now generated as RGBA at 512×512, fixing Bambu Studio, Handy app, and printer LCD showing the Bambu logo placeholder instead of the print preview.

--- a/src/bambox/pack.py
+++ b/src/bambox/pack.py
@@ -528,7 +528,9 @@ def repack_3mf(
                     gcode_str = gcode_bytes.decode(errors="replace")
                 except KeyError:
                     gcode_str = ""
-            if gcode_str:
+            if fname in ("Metadata/top_1.png", "Metadata/pick_1.png"):
+                thumbnail_overrides[fname] = _PLACEHOLDER_PNG
+            elif gcode_str:
                 try:
                     from bambox.thumbnail import gcode_thumbnail
 
@@ -674,8 +676,8 @@ def pack_gcode_3mf(
                         "Metadata/plate_1.png": main_png,
                         "Metadata/plate_no_light_1.png": main_png,
                         "Metadata/plate_1_small.png": small_png,
-                        "Metadata/top_1.png": main_png,
-                        "Metadata/pick_1.png": main_png,
+                        "Metadata/top_1.png": _PLACEHOLDER_PNG,
+                        "Metadata/pick_1.png": _PLACEHOLDER_PNG,
                     }
                 except Exception:
                     log.debug("Thumbnail generation failed, using placeholders", exc_info=True)

--- a/src/bambox/thumbnail.py
+++ b/src/bambox/thumbnail.py
@@ -8,8 +8,8 @@ import re
 
 def gcode_thumbnail(
     gcode: str | bytes,
-    width: int = 256,
-    height: int = 256,
+    width: int = 512,
+    height: int = 512,
 ) -> bytes:
     """Render a top-down toolpath preview from G-code as a PNG.
 
@@ -77,10 +77,10 @@ def gcode_thumbnail(
         return (int(ox + (mx - xmin) * scale), int(oy + (ymax - my) * scale))
 
     # Colours
-    bg = (25, 25, 30)
-    extrude_color = (0, 180, 160)  # teal
+    bg = (25, 25, 30, 255)
+    extrude_color = (0, 180, 160, 255)  # teal
 
-    img = Image.new("RGB", (width, height), bg)
+    img = Image.new("RGBA", (width, height), bg)
     draw = ImageDraw.Draw(img)
 
     # Draw extrusion moves
@@ -94,13 +94,13 @@ def gcode_thumbnail(
     return buf.getvalue()
 
 
-def _placeholder(width: int = 256, height: int = 256) -> bytes:
+def _placeholder(width: int = 512, height: int = 512) -> bytes:
     """Minimal branded placeholder when no toolpath data is available."""
     from PIL import Image, ImageDraw
 
-    bg = (25, 25, 30)
-    accent = (0, 150, 136)
-    img = Image.new("RGB", (width, height), bg)
+    bg = (25, 25, 30, 255)
+    accent = (0, 150, 136, 255)
+    img = Image.new("RGBA", (width, height), bg)
     draw = ImageDraw.Draw(img)
 
     # Simple bed rectangle with accent border

--- a/tests/test_thumbnail.py
+++ b/tests/test_thumbnail.py
@@ -47,9 +47,9 @@ class TestGcodeThumbnail:
         assert img.format == "PNG"
 
     def test_default_dimensions(self):
-        """Default output is 256x256."""
+        """Default output is 512x512."""
         img = _open_png(gcode_thumbnail(SIMPLE_GCODE))
-        assert img.size == (256, 256)
+        assert img.size == (512, 512)
 
     def test_custom_dimensions(self):
         """Custom width/height are respected."""
@@ -60,13 +60,13 @@ class TestGcodeThumbnail:
         """bytes G-code should work identically to str."""
         result = gcode_thumbnail(SIMPLE_GCODE.encode())
         img = _open_png(result)
-        assert img.size == (256, 256)
+        assert img.size == (512, 512)
 
     def test_empty_gcode_returns_placeholder(self):
         """Empty input should produce a placeholder image, not crash."""
         result = gcode_thumbnail("")
         img = _open_png(result)
-        assert img.size == (256, 256)
+        assert img.size == (512, 512)
 
     def test_no_extrusion_returns_placeholder(self):
         """Moves without E parameter are travel moves — no toolpath to render."""
@@ -77,7 +77,7 @@ G1 X20 Y20 F3000
 """
         result = gcode_thumbnail(gcode)
         # Should be same as placeholder (no extrusion moves parsed)
-        placeholder = _placeholder(256, 256)
+        placeholder = _placeholder()
         assert result == placeholder
 
     def test_negative_extrusion_not_rendered(self):
@@ -88,7 +88,7 @@ G1 X10 Y10 E-0.8
 G1 X20 Y20 E-0.8
 """
         result = gcode_thumbnail(gcode)
-        assert result == _placeholder(256, 256)
+        assert result == _placeholder()
 
     def test_startup_gcode_skipped(self):
         """G-code before the first Z_HEIGHT marker should be ignored."""
@@ -102,7 +102,7 @@ G1 X20 Y10 E0.5
 """
         result = gcode_thumbnail(gcode)
         # Should render — there's extrusion after Z_HEIGHT
-        assert result != _placeholder(256, 256)
+        assert result != _placeholder()
 
     def test_no_z_height_marker(self):
         """If no Z_HEIGHT marker exists, all G-code is parsed."""
@@ -113,14 +113,14 @@ G1 X20 Y20 E0.5
 """
         result = gcode_thumbnail(gcode)
         # Should still render extrusion moves
-        assert result != _placeholder(256, 256)
+        assert result != _placeholder()
 
     def test_multi_layer_renders(self):
         """Multi-layer G-code should produce a valid image."""
         result = gcode_thumbnail(MULTI_LAYER_GCODE)
         img = _open_png(result)
-        assert img.size == (256, 256)
-        assert result != _placeholder(256, 256)
+        assert img.size == (512, 512)
+        assert result != _placeholder()
 
     def test_extrude_color_present(self):
         """Rendered image should contain the teal extrusion color."""
@@ -129,17 +129,16 @@ G1 X20 Y20 E0.5
         raw = img.tobytes()
         found = any(
             raw[i] == 0 and raw[i + 1] == 180 and raw[i + 2] == 160
-            for i in range(0, len(raw) - 2, 3)
+            for i in range(0, len(raw) - 3, 4)
         )
         assert found, "Extrusion color (teal) not found in rendered image"
 
     def test_background_color(self):
-        """Background should be dark (25, 25, 30)."""
+        """Background should be dark (25, 25, 30, 255)."""
         result = gcode_thumbnail(SIMPLE_GCODE)
         img = _open_png(result)
-        bg = (25, 25, 30)
         # Corner pixel should be background
-        assert img.getpixel((0, 0)) == bg
+        assert img.getpixel((0, 0)) == (25, 25, 30, 255)
 
     def test_case_insensitive_gcode(self):
         """G-code commands should be parsed case-insensitively."""
@@ -149,7 +148,7 @@ g1 x10 y10 e0.5
 g1 x20 y10 e0.5
 """
         result = gcode_thumbnail(gcode)
-        assert result != _placeholder(256, 256)
+        assert result != _placeholder()
 
     def test_g0_moves_with_extrusion(self):
         """G0 rapid moves with E should also be rendered."""
@@ -159,7 +158,7 @@ G0 X10 Y10 E0.5
 G0 X20 Y10 E0.5
 """
         result = gcode_thumbnail(gcode)
-        assert result != _placeholder(256, 256)
+        assert result != _placeholder()
 
     def test_single_point_no_crash(self):
         """A single extrusion move from origin should not crash."""
@@ -169,7 +168,7 @@ G1 X10 Y10 E0.5
 """
         result = gcode_thumbnail(gcode)
         img = _open_png(result)
-        assert img.size == (256, 256)
+        assert img.size == (512, 512)
 
 
 # -- _placeholder --------------------------------------------------------------
@@ -183,7 +182,7 @@ class TestPlaceholder:
 
     def test_default_dimensions(self):
         img = _open_png(_placeholder())
-        assert img.size == (256, 256)
+        assert img.size == (512, 512)
 
     def test_custom_dimensions(self):
         img = _open_png(_placeholder(128, 64))
@@ -191,7 +190,7 @@ class TestPlaceholder:
 
     def test_background_color(self):
         img = _open_png(_placeholder())
-        assert img.getpixel((0, 0)) == (25, 25, 30)
+        assert img.getpixel((0, 0)) == (25, 25, 30, 255)
 
     def test_accent_border_present(self):
         """The bed rectangle outline should use the accent color."""
@@ -199,6 +198,6 @@ class TestPlaceholder:
         raw = img.tobytes()
         found = any(
             raw[i] == 0 and raw[i + 1] == 150 and raw[i + 2] == 136
-            for i in range(0, len(raw) - 2, 3)
+            for i in range(0, len(raw) - 3, 4)
         )
         assert found, "Accent border color not found in placeholder"


### PR DESCRIPTION
## Summary

- PNG mode changed from RGB to RGBA — Bambu Studio, Handy app, and printer LCD all showed the Bambu logo placeholder instead of the print preview; comparison against a BambuStudio reference archive identified RGBA as the expected format
- Main thumbnail size corrected from 256×256 to 512×512 (128×128 small thumbnail unchanged)
- `top_1.png` and `pick_1.png` now use the transparent 1×1 placeholder instead of a copy of the toolpath render — Bambu renders those from 3D angle views we cannot produce

The fix applies to both `pack_gcode_3mf` (new archives) and `repack_3mf` (regenerated missing thumbnails). Existing thumbnails in a source 3mf that pass the 1 KB size check are not touched on repack.

Closes #240

## Test plan

- [ ] All 565 existing tests pass
- [ ] Pack a fresh `.gcode.3mf` and verify `plate_1.png` is 512×512 RGBA in the archive
- [ ] Open the packed file in Bambu Studio — confirm print preview thumbnail is visible
- [ ] Check Bambu Handy app and printer LCD show the thumbnail

🤖 Generated with [Claude Code](https://claude.com/claude-code)