### PR TITLE
fix: back up original file before repack_3mf overwrites it

### DIFF
--- a/changes/242.bugfix
+++ b/changes/242.bugfix
@@ -1,0 +1,1 @@
+repack_3mf now backs up the original file before overwriting it, and restores it automatically if the write fails.

--- a/src/bambox/pack.py
+++ b/src/bambox/pack.py
@@ -572,7 +572,14 @@ def repack_3mf(
             if plate_json_override is not None:
                 zout.writestr(_PLATE_JSON_PATH, plate_json_override)
 
-    path.write_bytes(buf.getvalue())
+    backup = path.with_name(path.name + ".bak")
+    path.rename(backup)
+    try:
+        path.write_bytes(buf.getvalue())
+    except Exception:
+        backup.rename(path)
+        raise
+    backup.unlink()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -13,6 +13,8 @@ from io import BytesIO
 from pathlib import Path
 from xml.etree import ElementTree as ET
 
+import pytest
+
 from bambox.pack import (
     BAMBU_STUDIO_VERSION,
     FilamentInfo,
@@ -729,6 +731,34 @@ class TestRepack3mf:
         with zipfile.ZipFile(out) as z:
             si = z.read("Metadata/slice_info.config").decode()
             assert 'value="original"' in si
+
+    def test_repack_creates_and_removes_backup(self, tmp_path: Path) -> None:
+        """repack_3mf writes a .bak alongside the file and removes it on success."""
+        from bambox.pack import repack_3mf
+
+        out = self._make_3mf(tmp_path)
+        original_bytes = out.read_bytes()
+        repack_3mf(out)
+        backup = out.with_name(out.name + ".bak")
+        assert not backup.exists(), "backup should be removed after successful repack"
+        assert out.read_bytes() != original_bytes, "repacked file should differ from original"
+
+    def test_repack_restores_backup_on_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """repack_3mf restores the original file if the write step raises."""
+        from bambox.pack import repack_3mf
+
+        out = self._make_3mf(tmp_path)
+        original_bytes = out.read_bytes()
+
+        def _fail(_data: bytes) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(out.__class__, "write_bytes", lambda _self, data: _fail(data))
+        with pytest.raises(OSError, match="disk full"):
+            repack_3mf(out)
+        assert out.read_bytes() == original_bytes, "original should be restored after failed repack"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `repack_3mf` was modifying the source `.gcode.3mf` in-place with no safety net — a failed write (disk full, permission error, interrupted process) would corrupt or destroy the original
- Now renames the original to `<name>.gcode.3mf.bak` before writing the new archive
- Restores the backup automatically if the write raises; removes it on success

## Test plan

- [ ] `test_repack_creates_and_removes_backup` — confirms `.bak` is gone after a successful repack and the file changed
- [ ] `test_repack_restores_backup_on_failure` — confirms original is restored when the write step raises

🤖 Generated with [Claude Code](https://claude.com/claude-code)