### PR TITLE
fix: use PNG header check instead of size threshold for thumbnail validity

### DIFF
--- a/changes/243.bugfix
+++ b/changes/243.bugfix
@@ -1,0 +1,1 @@
+Fix `repack` incorrectly replacing valid OrcaSlicer thumbnails with a 1×1 placeholder, which broke Bambu Connect

--- a/src/bambox/pack.py
+++ b/src/bambox/pack.py
@@ -147,6 +147,23 @@ MODEL_SETTINGS_RELS_XML = """\
 </Relationships>"""
 
 # 1x1 transparent PNG (67 bytes) — minimal valid placeholder thumbnail.
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+def _is_valid_thumbnail(data: bytes) -> bool:
+    """Return True if *data* is a PNG image with dimensions larger than 1×1.
+
+    Reads only the 24-byte PNG signature + IHDR chunk — no PIL required.
+    PNG spec: bytes 0-7 = magic, bytes 8-15 = IHDR length+type,
+    bytes 16-19 = width (big-endian uint32), bytes 20-23 = height.
+    """
+    if len(data) < 24 or not data.startswith(_PNG_MAGIC):
+        return False
+    width = int.from_bytes(data[16:20], "big")
+    height = int.from_bytes(data[20:24], "big")
+    return width > 1 and height > 1
+
+
 _PLACEHOLDER_PNG = (
     b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
     b"\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
@@ -433,8 +450,6 @@ def repack_3mf(
         filament_colors: Hex colors per filament slot.
         min_slots: Minimum slot count for per-filament arrays (default 5).
     """
-    _THUMB_MIN_SIZE = 1024
-
     with zipfile.ZipFile(path, "r") as zin:
         # --- Fix project_settings.config ---
         try:
@@ -517,8 +532,8 @@ def repack_3mf(
         for fname in thumb_files:
             try:
                 existing = zin.read(fname)
-                if len(existing) >= _THUMB_MIN_SIZE:
-                    continue  # valid thumbnail
+                if _is_valid_thumbnail(existing):
+                    continue  # valid thumbnail — keep as-is
             except KeyError:
                 pass
             # Need to generate — load G-code lazily

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -318,9 +318,9 @@ class TestRepack:
             assert 'key="thumbnail_file"' in ms
 
     def test_regenerates_broken_thumbnails(self, tmp_path: Path) -> None:
-        """Repack regenerates thumbnails that are too small (broken)."""
+        """Repack regenerates thumbnails that are not valid PNGs."""
         threemf = tmp_path / "test.gcode.3mf"
-        # Tiny thumbnail simulates headless OrcaSlicer output
+        # Corrupt/empty thumbnail simulates headless OrcaSlicer without Xvfb
         _make_orca_3mf(threemf, thumbnail=b"\x89PNG tiny")
 
         repack_3mf(threemf)
@@ -331,8 +331,8 @@ class TestRepack:
             assert png != b"\x89PNG tiny"
 
     def test_preserves_valid_thumbnails(self, tmp_path: Path) -> None:
-        """Repack keeps thumbnails that are large enough."""
-        valid_png = b"\x89PNG" + b"\x00" * 2000  # > 1024 bytes
+        """Repack keeps thumbnails that are valid PNGs with dimensions > 1×1."""
+        valid_png = (FIXTURES / "plate_1.png").read_bytes()
         threemf = tmp_path / "test.gcode.3mf"
         _make_orca_3mf(threemf, thumbnail=valid_png)
 


### PR DESCRIPTION
Closes #243

## Summary

- `repack_3mf` replaced OrcaSlicer's valid 128×128 `plate_1_small.png` (~557 bytes) with a 1×1 placeholder because the old 1024-byte size threshold incorrectly flagged it as broken
- Repacked `.gcode.3mf` files failed to open in Bambu Connect as a result
- Replace the byte-count heuristic with a dependency-free PNG-header check: verify PNG magic (`\x89PNG\r\n\x1a\n`) and read IHDR width/height (bytes 16–23); keep thumbnail if dimensions > 1×1

## Test plan
- [ ] `uv run pytest tests/test_pack.py tests/test_e2e.py` — 85 passed
- [ ] `uv run ruff check src/bambox/pack.py tests/test_e2e.py` — clean
- [ ] `uv run mypy src/bambox/pack.py` — clean
- [ ] Manual: `bambox repack` on multi-part orca example preserves all thumbnails unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)