### PR TITLE
Fix E002 false positive for OrcaSlicer BBL G-code and W003 weight=0

### DIFF
--- a/changes/245.bugfix
+++ b/changes/245.bugfix
@@ -1,0 +1,1 @@
+Fix E002 false positive for OrcaSlicer BBL G-code and W003 weight=0 from slice_info.config

--- a/src/bambox/pack.py
+++ b/src/bambox/pack.py
@@ -424,6 +424,39 @@ def _patch_slice_info_printer_model(xml_str: str, printer_model_id: str) -> str:
     )
 
 
+def _patch_slice_info_weight(xml_str: str) -> str | None:
+    """Fix weight=0 in slice_info.config by summing filament used_g values.
+
+    OrcaSlicer occasionally emits weight="0" in the plate metadata while the
+    per-filament ``used_g`` attributes are correct.  Returns the patched XML
+    or None if the weight is already non-zero (no change needed).
+    """
+    import xml.etree.ElementTree as ET
+
+    try:
+        root = ET.fromstring(xml_str)
+    except ET.ParseError:
+        return None
+    plate = root.find("plate")
+    if plate is None:
+        return None
+    meta = {el.get("key", ""): el.get("value", "") for el in plate.findall("metadata")}
+    weight_str = meta.get("weight", "0")
+    try:
+        if float(weight_str) > 0:
+            return None  # already correct
+    except ValueError:
+        return None
+    total_g = sum(float(f.get("used_g", "0") or "0") for f in plate.findall("filament"))
+    if total_g <= 0:
+        return None  # nothing to fix
+    return re.sub(
+        r'(<metadata key="weight" value=")[^"]*(")',
+        rf"\g<1>{total_g:.2f}\g<2>",
+        xml_str,
+    )
+
+
 def repack_3mf(
     path: Path,
     *,
@@ -510,12 +543,18 @@ def repack_3mf(
         except KeyError:
             si_raw = None
         si_patched: str | None = None
-        if si_raw is not None and machine:
-            from bambox.cura import PRINTER_MODEL_IDS
+        if si_raw is not None:
+            # Fix weight=0 when per-filament used_g values are available
+            weight_fix = _patch_slice_info_weight(si_raw)
+            if weight_fix is not None:
+                si_patched = weight_fix
+            if machine:
+                from bambox.cura import PRINTER_MODEL_IDS
 
-            model_id = PRINTER_MODEL_IDS.get(machine.lower(), "")
-            if model_id:
-                si_patched = _patch_slice_info_printer_model(si_raw, model_id)
+                model_id = PRINTER_MODEL_IDS.get(machine.lower(), "")
+                if model_id:
+                    base = si_patched if si_patched is not None else si_raw
+                    si_patched = _patch_slice_info_printer_model(base, model_id)
 
         # --- Fix thumbnails ---
         thumb_files = [

--- a/src/bambox/validate.py
+++ b/src/bambox/validate.py
@@ -302,7 +302,19 @@ def _check_temperature_commands(gcode: str, findings: list[Finding]) -> None:
 
 
 def _check_toolchange_feedrate(gcode: str, findings: list[Finding]) -> None:
-    """E002: M620.1 E feedrate must be >= 100 mm/min (linear, not volumetric)."""
+    """E002: M620.1 E feedrate must be >= 1 mm/min.
+
+    OrcaSlicer computes M620.1 E feedrate as
+    ``filament_max_volumetric_speed / 2.4053 * 60``, which can legitimately
+    produce values below 100 mm/min for low-speed filaments. Only flag values
+    so low (< 1 mm/min) that they must be a raw volumetric rate passed
+    without the linear conversion.
+
+    Skip entirely for BBL-format G-code (HEADER_BLOCK_START present) since
+    OrcaSlicer always applies the correct conversion formula.
+    """
+    if _RE_HEADER_START.search(gcode):
+        return  # OrcaSlicer output — feedrate is correctly computed
     for line in gcode.splitlines():
         stripped = line.strip()
         if stripped.startswith(";"):
@@ -310,13 +322,13 @@ def _check_toolchange_feedrate(gcode: str, findings: list[Finding]) -> None:
         m = _RE_TOOLCHANGE_FEEDRATE.search(stripped)
         if m:
             feedrate = float(m.group(1))
-            if feedrate < 100:
+            if feedrate < 1:
                 findings.append(
                     Finding(
                         Severity.ERROR,
                         "E002",
                         f"Toolchange feedrate too low: F{feedrate} "
-                        "(< 100 mm/min, likely raw volumetric)",
+                        "(< 1 mm/min, likely raw volumetric rate not converted to mm/min)",
                         stripped[:120],
                     )
                 )

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -152,15 +152,26 @@ class TestTemperatureCommands:
 # ---------------------------------------------------------------------------
 
 
+_NON_BBL_GCODE = "G1 X10 Y10 E1 F600\n"  # no HEADER_BLOCK_START
+
+
 class TestToolchangeFeedrate:
     def test_low_feedrate_detected(self, tmp_path: Path) -> None:
-        gcode = MINIMAL_GCODE + "M620.1 E F12 T240\n"
+        # Non-BBL G-code with sub-1 mm/min feedrate (likely raw volumetric)
+        gcode = _NON_BBL_GCODE + "M620.1 E F0.5 T240\n"
         path = build_valid_3mf(tmp_path, gcode=gcode)
         result = validate_3mf(path)
         assert any(f.code == "E002" for f in result.errors)
 
     def test_correct_feedrate_passes(self, tmp_path: Path) -> None:
-        gcode = MINIMAL_GCODE + "M620.1 E F299 T240\n"
+        gcode = _NON_BBL_GCODE + "M620.1 E F299 T240\n"
+        path = build_valid_3mf(tmp_path, gcode=gcode)
+        result = validate_3mf(path)
+        assert not any(f.code == "E002" for f in result.findings)
+
+    def test_bbl_orca_feedrate_not_flagged(self, tmp_path: Path) -> None:
+        # OrcaSlicer BBL G-code: F49.89 is correct for ABS at 2.0 mm³/s
+        gcode = MINIMAL_GCODE + "M620.1 E F49.8898 T240\n"
         path = build_valid_3mf(tmp_path, gcode=gcode)
         result = validate_3mf(path)
         assert not any(f.code == "E002" for f in result.findings)


### PR DESCRIPTION
## Summary

- **E002 false positive**: OrcaSlicer BBL G-code with `M620.1 E F49.89` was incorrectly flagged. The feedrate is legitimately low for filaments with low `filament_max_volumetric_speed` (formula: `speed / 2.4053 * 60`). Fix: skip E002 entirely for BBL-format G-code (has `; HEADER_BLOCK_START`); for non-BBL lower threshold from 100 → 1 mm/min.
- **W003 weight=0**: OrcaSlicer occasionally emits `weight="0"` in `slice_info.config` plate metadata while per-filament `used_g` values are correct. Fix: `repack` now sums `used_g` values and patches weight when it is 0.

## Test plan

- [ ] `uv run pytest tests/test_pack.py tests/test_validate.py tests/test_e2e.py` — all pass
- [ ] `uv run bambox validate` on OrcaSlicer multi-material BBL output no longer reports E002 or W003
- [ ] `uv run bambox repack` produces a file openable by Bambu Connect

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)