### PR TITLE
Strip ;MESH: path comments from CuraEngine G-code

### DIFF
--- a/changes/257.bugfix
+++ b/changes/257.bugfix
@@ -1,0 +1,1 @@
+Strip ``;MESH:`` path comments from CuraEngine G-code output to avoid leaking internal Docker container paths.

--- a/src/bambox/gcode_compat.py
+++ b/src/bambox/gcode_compat.py
@@ -151,6 +151,7 @@ def _translate_cura(text: str) -> str:
         )
 
     text = re.sub(r";LAYER:(\d+)", _layer_sub, text)
+    text = re.sub(r"^;MESH:.*\n?", "", text, flags=re.MULTILINE)
     return text
 
 

--- a/tests/test_gcode_compat.py
+++ b/tests/test_gcode_compat.py
@@ -106,6 +106,20 @@ def test_cura_movement_preserved():
     assert "G1 X10 Y10 E1" in result
 
 
+def test_cura_mesh_comments_stripped():
+    gcode = (
+        b";FLAVOR:Marlin\n"
+        b";LAYER_COUNT:1\n"
+        b";MESH:/work/output/.cura-staging/plate.stl\n"
+        b";LAYER:0\n"
+        b"G1 X10 Y10 E1\n"
+        b";MESH:NONMESH\n"
+    )
+    result = translate_to_bbl(gcode).decode()
+    assert ";MESH:" not in result
+    assert "G1 X10 Y10 E1" in result
+
+
 # --- translate_to_bbl (PrusaSlicer) ---
 
 


### PR DESCRIPTION
CuraEngine emits `;MESH:/work/output/.cura-staging/plate.stl` comments that leak the internal Docker container path into the final G-code. One line of regex in `_translate_cura()` strips them.

Closes #257