### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ This changelog is managed by [towncrier](https://towncrier.readthedocs.io/).
 
 <!-- towncrier release notes start -->
 
+## 0.5.0 — 2026-04-24
+
+### Misc
+
+- Update cura.py comments to reflect that modern CuraEngine (5.x+) resolves variable placeholders; document remaining bambox post-processing responsibilities. ([#205](https://github.com/estampo/bambox/pull/205))
+- Add LICENSE file (MIT for bambox source); tighten THIRD-PARTY-NOTICES to explicitly state profile files remain under AGPL-3.0.
+- Extract cloud printing into a separate `boo-cloud` project; remove `bridge.py`, `credentials.py`, `auth.py` and all cloud CLI commands (`login`, `print`, `cancel`, `status`, `daemon`) from bambox.
+- Move cloud printing docs to boo-cloud; rewrite README, CLAUDE.md, ROADMAP.md, SECURITY.md to remove cloud/bridge references.
+- Remove bridge/ Rust source, build-bridge and publish-docker workflows, install scripts from bambox; bridge now lives in estampo/boo-cloud.
+
+
 ## 0.4.7 — 2026-04-24
 
 ### Bugfixes

--- a/changes/+extract-boo-cloud.misc
+++ b/changes/+extract-boo-cloud.misc
@@ -1,1 +1,0 @@
-Extract cloud printing into a separate `boo-cloud` project; remove `bridge.py`, `credentials.py`, `auth.py` and all cloud CLI commands (`login`, `print`, `cancel`, `status`, `daemon`) from bambox.

--- a/changes/+license-attribution.misc
+++ b/changes/+license-attribution.misc
@@ -1,1 +1,0 @@
-Add LICENSE file (MIT for bambox source); tighten THIRD-PARTY-NOTICES to explicitly state profile files remain under AGPL-3.0.

--- a/changes/+move-cloud-docs.misc
+++ b/changes/+move-cloud-docs.misc
@@ -1,1 +1,0 @@
-Move cloud printing docs to boo-cloud; rewrite README, CLAUDE.md, ROADMAP.md, SECURITY.md to remove cloud/bridge references.

--- a/changes/+remove-bridge.misc
+++ b/changes/+remove-bridge.misc
@@ -1,1 +1,0 @@
-Remove bridge/ Rust source, build-bridge and publish-docker workflows, install scripts from bambox; bridge now lives in estampo/boo-cloud.

--- a/changes/205.misc
+++ b/changes/205.misc
@@ -1,1 +1,0 @@
-Update cura.py comments to reflect that modern CuraEngine (5.x+) resolves variable placeholders; document remaining bambox post-processing responsibilities.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = ["src/bambox"]
 
 [project]
 name = "bambox"
-version = "0.4.7"
+version = "0.5.0"
 description = "Package plain G-code into Bambu Lab .gcode.3mf files"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Release v0.5.0


### Misc

- Update cura.py comments to reflect that modern CuraEngine (5.x+) resolves variable placeholders; document remaining bambox post-processing responsibilities. ([#205](https://github.com/estampo/bambox/pull/205))
- Add LICENSE file (MIT for bambox source); tighten THIRD-PARTY-NOTICES to explicitly state profile files remain under AGPL-3.0.
- Extract cloud printing into a separate `boo-cloud` project; remove `bridge.py`, `credentials.py`, `auth.py` and all cloud CLI commands (`login`, `print`, `cancel`, `status`, `daemon`) from bambox.
- Move cloud printing docs to boo-cloud; rewrite README, CLAUDE.md, ROADMAP.md, SECURITY.md to remove cloud/bridge references.
- Remove bridge/ Rust source, build-bridge and publish-docker workflows, install scripts from bambox; bridge now lives in estampo/boo-cloud.

---
**Merge this PR to trigger the release pipeline.**
The release workflow will build the package, validate on TestPyPI, create the tag, create the GitHub Release, then publish to PyPI.