### PR TITLE
Fix legal: remove stale CuraEngine README ref, drop imprecise AGPLv3+ classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,8 +287,7 @@ uv run pytest
 
 The bundled machine and filament profiles under `src/bambox/profiles/` are
 derived from OrcaSlicer and BambuStudio slicer profiles (AGPL-3.0-era
-sources). The CuraEngine printer definitions under `src/bambox/data/cura/`
-use the CuraEngine schema (LGPL-3.0). See
+sources). See
 [`THIRD-PARTY-NOTICES`](THIRD-PARTY-NOTICES) for full provenance, file lists,
 and license details. The file is also shipped inside the installed package
 so it remains discoverable after `pip install`.

--- a/changes/+legal-classifier-readme.misc
+++ b/changes/+legal-classifier-readme.misc
@@ -1,0 +1,1 @@
+Remove stale CuraEngine path from README and drop imprecise AGPLv3+ PyPI classifier (SPDX expression is AGPL-3.0-only).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ authors = [{ name = "estampo contributors" }]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: MIT License",
-    "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
     "Programming Language :: Python :: 3",
     "Topic :: Printing",
 ]


### PR DESCRIPTION
## Summary

- Remove sentence in `README.md` referencing `src/bambox/data/cura/` — that path no longer exists.
- Drop the `GNU Affero General Public License v3 or later (AGPLv3+)` PyPI classifier from `pyproject.toml`. The SPDX license expression is `AGPL-3.0-only`, and PyPI has no matching `AGPL-3.0-only` classifier. The MIT classifier remains; AGPL provenance is documented in `README.md`, `LICENSES/AGPL-3.0.txt`, and `THIRD-PARTY-NOTICES`.

## Test plan

- [ ] `uv run ruff check src tests` — passes
- [ ] `uv run ruff format --check src tests` — passes
- [ ] `uv run mypy src/bambox` — passes
- [ ] `uv run pytest` — passes (pre-existing `test_e2e_cura_vs_bbl` failures unrelated to this change)
- [ ] `uv build` — hatchling accepts the updated classifiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)